### PR TITLE
fix(planned-entries): allow category changes and fix organization in link modal

### DIFF
--- a/backend/internal/application/financial/repository.go
+++ b/backend/internal/application/financial/repository.go
@@ -1666,6 +1666,7 @@ type modifyPlannedEntryParams struct {
 	ExpectedDay      *int
 	EntryType        *string
 	IsActive         *bool
+	CategoryID       *int
 }
 
 const modifyPlannedEntryQuery = `
@@ -1687,6 +1688,7 @@ const modifyPlannedEntryQuery = `
 		expected_day = COALESCE($12, expected_day),
 		entry_type = COALESCE($13, entry_type),
 		is_active = COALESCE($14, is_active),
+		category_id = COALESCE($15, category_id),
 		updated_at = CURRENT_TIMESTAMP
 	WHERE planned_entry_id = $1
 		AND user_id = $2
@@ -1719,7 +1721,7 @@ func (r *repository) ModifyPlannedEntry(ctx context.Context, params modifyPlanne
 		params.PlannedEntryID, params.UserID, params.OrganizationID,
 		params.PatternID, params.SavingsGoalID, params.Description, params.Amount, params.AmountMin,
 		params.AmountMax, params.ExpectedDayStart, params.ExpectedDayEnd,
-		params.ExpectedDay, params.EntryType, params.IsActive)
+		params.ExpectedDay, params.EntryType, params.IsActive, params.CategoryID)
 	return entry, err
 }
 

--- a/backend/internal/application/financial/service.go
+++ b/backend/internal/application/financial/service.go
@@ -1467,6 +1467,7 @@ type UpdatePlannedEntryInput struct {
 	EntryType        *string
 	IsActive         *bool
 	SavingsGoalID    *int // Use -1 to clear
+	CategoryID       *int
 }
 
 func (s *service) UpdatePlannedEntry(ctx context.Context, params UpdatePlannedEntryInput) (PlannedEntry, error) {
@@ -1485,6 +1486,7 @@ func (s *service) UpdatePlannedEntry(ctx context.Context, params UpdatePlannedEn
 		EntryType:        params.EntryType,
 		IsActive:         params.IsActive,
 		SavingsGoalID:    params.SavingsGoalID,
+		CategoryID:       params.CategoryID,
 	})
 	if err != nil {
 		return PlannedEntry{}, errors.Wrap(err, "failed to update planned entry")

--- a/backend/internal/web/financial/handler.go
+++ b/backend/internal/web/financial/handler.go
@@ -1269,6 +1269,7 @@ func (h *Handler) UpdatePlannedEntry(w http.ResponseWriter, r *http.Request) {
 		IsActive         *bool    `json:"is_active,omitempty"`
 		PatternID        *int     `json:"pattern_id,omitempty"`
 		SavingsGoalID    *int     `json:"savings_goal_id,omitempty"`
+		CategoryID       *int     `json:"category_id,omitempty"`
 	}
 
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
@@ -1309,6 +1310,7 @@ func (h *Handler) UpdatePlannedEntry(w http.ResponseWriter, r *http.Request) {
 		IsActive:         req.IsActive,
 		PatternID:        req.PatternID,
 		SavingsGoalID:    req.SavingsGoalID,
+		CategoryID:       req.CategoryID,
 	})
 	if err != nil {
 		responses.NewError(w, err)

--- a/frontend/src/components/TransactionPlannedEntryLinkModal.tsx
+++ b/frontend/src/components/TransactionPlannedEntryLinkModal.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { useAuth } from '../contexts/AuthContext';
+import { useOrganization } from '../contexts/OrganizationContext';
 import type { PlannedEntryWithStatus } from '../types/budget';
 import type { Category } from '../types/category';
 import type { Transaction } from '../types/transaction';
@@ -20,6 +21,8 @@ export default function TransactionPlannedEntryLinkModal({
   onLink,
 }: TransactionPlannedEntryLinkModalProps) {
   const { token } = useAuth();
+  const { activeOrganization } = useOrganization();
+  const organizationId = activeOrganization?.organization_id?.toString() || '1';
   const [entries, setEntries] = useState<PlannedEntryWithStatus[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -44,7 +47,7 @@ export default function TransactionPlannedEntryLinkModal({
       try {
         const result = await getPlannedEntriesForMonth(txMonth, txYear, {
           token,
-          organizationId: '1',
+          organizationId,
         });
         setEntries(result || []);
       } catch (err) {
@@ -55,7 +58,7 @@ export default function TransactionPlannedEntryLinkModal({
     };
 
     fetchEntries();
-  }, [token, txMonth, txYear]);
+  }, [token, txMonth, txYear, organizationId]);
 
   const handleLink = async (entryId: number) => {
     if (!token) return;
@@ -69,7 +72,7 @@ export default function TransactionPlannedEntryLinkModal({
           month: txMonth,
           year: txYear,
         },
-        { token, organizationId: '1' }
+        { token, organizationId }
       );
       onLink();
     } catch (err) {

--- a/frontend/src/types/budget.ts
+++ b/frontend/src/types/budget.ts
@@ -209,6 +209,7 @@ export interface UpdatePlannedEntryRequest {
   is_active?: boolean;
   pattern_id?: number;
   savings_goal_id?: number; // Link to savings goal - matched transactions inherit this
+  category_id?: number;
 }
 
 export interface GenerateMonthlyInstancesRequest {


### PR DESCRIPTION
Bug #1: Category changes were not persisting because category_id was missing
from the UpdatePlannedEntry endpoint. Added category_id field at all layers:
- Backend handler request struct
- Service UpdatePlannedEntryInput struct
- Repository modifyPlannedEntryParams struct and SQL UPDATE query
- Frontend UpdatePlannedEntryRequest interface

Bug #2: Transaction link modal was hardcoding organizationId: '1', causing
planned entries to not show for users in other organizations. Now uses
useOrganization() hook to get the active organization.