### PR TITLE
fix(planned-entries): include scheduled entries in link modal

### DIFF
--- a/frontend/src/components/TransactionPlannedEntryLinkModal.tsx
+++ b/frontend/src/components/TransactionPlannedEntryLinkModal.tsx
@@ -100,8 +100,8 @@ export default function TransactionPlannedEntryLinkModal({
     if (searchTerm && !entry.Description.toLowerCase().includes(searchTerm.toLowerCase())) {
       return false;
     }
-    // Only show pending entries (not already matched)
-    if (entry.Status !== 'pending' && entry.Status !== 'missed') {
+    // Exclude entries that are already matched or dismissed
+    if (entry.Status === 'matched' || entry.Status === 'dismissed') {
       return false;
     }
     return true;


### PR DESCRIPTION
The filter was only showing entries with status 'pending' or 'missed',
which excluded 'scheduled' entries (entries on time, before due date).
Changed to exclude only 'matched' and 'dismissed' entries instead.