### PR TITLE
docs: add frontend screen documentation

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -41,6 +41,7 @@ Personal finance management system with Go backend, React frontend, PostgreSQL d
 | Database schema | [database.md](./database.md) |
 | Domain entities | [domains.md](./domains.md) |
 | Authentication | [auth.md](./auth.md) |
+| **Frontend screens** | [screens/index.md](./screens/index.md) |
 | Project conventions | [conventions.md](./conventions.md) |
 | Key files location | [files.md](./files.md) |
 | Development setup | [setup.md](./setup.md) |

--- a/docs/screens/budgets.md
+++ b/docs/screens/budgets.md
@@ -1,0 +1,155 @@
+# Budgets Screen (CategoryBudgetDashboard)
+
+**File:** `frontend/src/components/CategoryBudgetDashboard.tsx`
+
+## Purpose
+
+Monthly budget planning and tracking. Manage category budgets, planned entries, and match transactions.
+
+## What the User Sees
+
+### Month Navigation Header
+
+- Previous/Next month arrows
+- Current month name and year
+- "Mês atual" badge if viewing current month
+- "Hoje" button to return to current month
+- Action buttons: "+ Entrada", "+ Orçamento"
+
+### Monthly Summary Card
+
+| Metric | Description |
+|--------|-------------|
+| Planejado | Sum of planned amounts (expenses only) |
+| Gasto | Sum of actual spending (expenses only) |
+| Progresso | Percentage bar with color-coded status |
+
+Quick stats footer:
+- Number of categories
+- Number of planned entries
+- "Copiar do mês anterior" link (if previous month has budgets and current is empty)
+
+### MonthlyBudgetCard
+
+Renders via `MonthlyBudgetCard.tsx`. Shows:
+
+**Category Budgets (Expense)**
+- Category icon, name, color
+- Planned vs actual amount
+- Progress bar with health indicator
+- Variance percentage
+- Edit/Delete actions
+- Click opens CategoryTransactionsModal
+
+**Category Budgets (Income)**
+- Similar to expenses but tracked separately
+- Shows actual income vs planned
+
+**Planned Entries Section**
+- List of expected transactions
+- Status badges: pending, matched, dismissed, missed
+- Expected day/range
+- Amount or amount range
+- Linked savings goal indicator
+- Actions: match, unmatch, dismiss, undismiss, edit, delete
+
+### Empty State
+
+When no budgets/entries:
+- Icon placeholder
+- "Nenhum orçamento para {month} {year}"
+- "Copiar do mês anterior" button (if applicable)
+- "Criar Orçamento" button
+
+## Modals
+
+### Create/Edit Budget Modal
+
+Fields:
+- **Categoria**: Dropdown (disabled when editing)
+- **Tipo de Orçamento**: fixed, calculated, maior
+- **Valor Planejado**: Required for fixed, optional for others
+
+See [modals.md](./modals.md) for PlannedEntryForm details.
+
+### Transaction Matcher Modal
+
+Opens when clicking "match" on a planned entry. Shows:
+- Transactions for the same month
+- Filter by category
+- Search by description
+- Select to link
+
+### CategoryTransactionsModal
+
+Opens when clicking a category budget card. Shows:
+- Actual vs planned amounts
+- List of transactions in that category
+- List of planned entries in that category
+- Click-through to edit transactions/entries
+
+## Data Sources
+
+| Data | Source |
+|------|--------|
+| Category budgets | `getCategoryBudgets()` |
+| Planned entries | `getPlannedEntriesForMonth()` |
+| Categories | `GET /financial/categories` |
+| Transactions | `GET /financial/accounts/{id}/transactions` |
+| Savings goals | `listSavingsGoals()` |
+
+## Business Rules
+
+### Actual Spending Calculation
+
+For "Maior" budget type, actual = Planned Entries + Unmatched Transactions:
+
+1. Build set of matched transaction IDs per month
+2. Add planned entry amounts (expenses only, not dismissed)
+   - Use `MatchedAmount` if matched, else `Amount`
+3. Add unmatched transaction amounts (debits only)
+4. Income categories tracked separately via credit transactions
+
+### Budget Types
+
+| Type | Behavior |
+|------|----------|
+| `fixed` | User sets planned amount manually |
+| `calculated` | Sum of linked planned entries |
+| `maior` | Max of fixed amount or sum of entries |
+
+### Planned Entry Status
+
+| Status | Meaning |
+|--------|---------|
+| `pending` | Not yet matched, expected date not passed |
+| `matched` | Linked to a transaction |
+| `dismissed` | User dismissed (excluded from calculations) |
+| `missed` | Expected date passed, not matched |
+
+### Consolidation
+
+Locks a budget to prevent changes. Used for closing past months.
+
+## Click Behaviors
+
+| Element | Action |
+|---------|--------|
+| Category budget card | Opens CategoryTransactionsModal |
+| "+ Orçamento" | Opens create budget modal |
+| "+ Entrada" | Opens create planned entry modal |
+| Edit budget icon | Opens edit budget modal |
+| Delete budget icon | Deletes budget (with confirmation in delete month) |
+| Match entry | Opens TransactionMatcherModal |
+| Unmatch entry | Calls `unmatchPlannedEntry()`, refreshes spending |
+| Dismiss entry | Calls `dismissPlannedEntry()`, refreshes spending |
+| Undismiss entry | Calls `undismissPlannedEntry()`, refreshes spending |
+| "Copiar do mês anterior" | Calls `copyCategoryBudgetsFromMonth()` |
+| Consolidate | Locks budgets via `consolidateCategoryBudget()` |
+
+## Links to Other Features
+
+- **Transactions**: Via CategoryTransactionsModal click-through
+- **Savings Goals**: Linked to planned entries
+- **Patterns**: Advanced patterns can auto-create planned entries
+- **Dashboard**: Budget data displayed on dashboard

--- a/docs/screens/dashboard.md
+++ b/docs/screens/dashboard.md
@@ -1,0 +1,101 @@
+# Dashboard Screen
+
+**File:** `frontend/src/components/Dashboard.tsx`
+
+## Purpose
+
+Main financial overview showing current month's summary, budget status, and actionable alerts.
+
+## What the User Sees
+
+### Hero Status Card
+
+Shows overall budget health with three states:
+
+| Status | Condition | Message | Color |
+|--------|-----------|---------|-------|
+| On-track | ≤80% spent | "Você está no caminho certo!" | Green (sage) |
+| Warning | 80-100% spent | "Atenção ao orçamento" | Orange (terra) |
+| Over-budget | >100% spent | "Orçamento excedido" | Red (rust) |
+| No budget | 0 planned | "Configure seu orçamento" | Gray (stone) |
+
+Displays:
+- Available amount (or "acima do limite" if negative)
+- Actual vs planned spending
+- Percentage used
+- Progress bar with day-of-month marker (vertical line)
+- Spending pace indicator (ahead/behind expected for current day)
+- End-of-month projection
+
+### Attention Section
+
+Only appears when there are items needing action:
+
+| Item | Trigger | Action |
+|------|---------|--------|
+| Uncategorized transactions | Count > 0 | "Categorizar" button → navigates to UncategorizedTransactions |
+| Missed planned entries | Status = 'missed' | Informational alert |
+| Over-budget categories | Actual > Planned | Shows badge "Excedido" |
+
+### Quick Stats Cards
+
+Three cards showing current month totals:
+- **Receitas** (Income): Sum of credit transactions
+- **Despesas** (Expenses): Sum of debit transactions
+- **Saldo** (Balance): Income - Expenses (green if positive, red if negative)
+
+### Category Expenses Section
+
+Shows top 8 expense categories with:
+- Category icon and name
+- Amount spent
+- Progress bar (colored by budget health)
+- Day-of-month marker for budgeted categories
+- Percentage of budget (if budgeted) or percentage of total (if not)
+- Pace indicator (+X% or -X% vs expected)
+
+### Planned Entries Summary
+
+Footer showing planned entry status:
+- Matched (green dot)
+- Pending (orange dot)
+- Missed (red dot) - only if > 0
+
+### All Organized Message
+
+Shows green "Tudo Organizado!" card when:
+- No uncategorized transactions
+- No attention items
+
+## Data Sources
+
+| Data | API Endpoint |
+|------|--------------|
+| Accounts | `GET /financial/accounts` |
+| Categories | `GET /financial/categories` |
+| Transactions | `GET /financial/accounts/{id}/transactions` (per account) |
+| Uncategorized | `GET /financial/transactions/uncategorized` |
+| Category budgets | `getCategoryBudgets()` |
+| Planned entries | `getPlannedEntriesForMonth()` |
+
+## Business Rules
+
+1. **Month Selection**: Uses most recent transaction date, falls back to current date
+2. **Ignored Transactions**: Excluded from all calculations
+3. **Income Categories**: Excluded from expense budget progress bar
+4. **Day Progress**: Calculated as `currentDay / daysInMonth`
+5. **Expected Spending**: `totalPlanned * dayProgressPercent / 100`
+6. **Spending Pace**: `(actual - expected) / expected * 100`
+
+## Click Behaviors
+
+| Element | Action |
+|---------|--------|
+| "Categorizar" button | Calls `onNavigateToUncategorized()` prop |
+| Category expense row | No action (view only) |
+
+## Links to Other Features
+
+- **Uncategorized Transactions**: Via "Categorizar" button
+- **Budgets**: Budget data displayed but no direct navigation
+- **Planned Entries**: Status shown in summary

--- a/docs/screens/index.md
+++ b/docs/screens/index.md
@@ -1,0 +1,48 @@
+# Frontend Screens Documentation
+
+Overview of all application screens and their behaviors.
+
+## Screen Map
+
+| Screen | File | Description |
+|--------|------|-------------|
+| [Login](./login.md) | `Login.tsx` | Authentication (magic link / password) |
+| [Dashboard](./dashboard.md) | `Dashboard.tsx` | Financial overview and alerts |
+| [Transactions](./transactions.md) | `TransactionList.tsx` | Transaction list with OFX import |
+| [Budgets](./budgets.md) | `CategoryBudgetDashboard.tsx` | Budget planning and tracking |
+| [Savings Goals](./savings-goals.md) | `SavingsGoalsPage.tsx` | Long-term savings tracking |
+| [Settings](./settings.md) | `SettingsPage.tsx` | Configuration hub (5 tabs) |
+
+## Modal Components
+
+Reusable modal components used across screens. See [modals.md](./modals.md).
+
+## Navigation Flow
+
+```
+Login → Dashboard
+           ↓
+    ┌──────┼──────┬──────────┐
+    ↓      ↓      ↓          ↓
+Transactions  Budgets  Goals  Settings
+    ↓          ↓              ↓
+    └── Shared Month Navigation ──┘
+```
+
+## Shared State
+
+| State | Hook | Screens |
+|-------|------|---------|
+| Month/Year selection | `useSelectedMonth` | Transactions, Budgets |
+| Auth token | `useAuth` | All screens |
+| Organization | `useOrganization` | All authenticated screens |
+
+## File Locations
+
+| Type | Path |
+|------|------|
+| Screens | `frontend/src/components/` |
+| Modals | `frontend/src/components/` |
+| Hooks | `frontend/src/hooks/` |
+| API clients | `frontend/src/api/` |
+| Types | `frontend/src/types/` |

--- a/docs/screens/login.md
+++ b/docs/screens/login.md
@@ -1,0 +1,83 @@
+# Login Screen
+
+**File:** `frontend/src/components/Login.tsx`
+
+## Purpose
+
+Authentication entry point supporting two methods: Magic Link and Password.
+
+## What the User Sees
+
+### Auth Mode Toggle
+
+Tab-style toggle between:
+- **Magic Link** (default): Passwordless email authentication
+- **Senha**: Traditional email + password
+
+### Magic Link Flow
+
+**Step 1: Email**
+- Email input field
+- "Enviar código" button
+- Hint: "Enviaremos um código de 4 dígitos para seu email"
+
+**Step 2: Code**
+- 4-digit code input (large, centered, monospace)
+- "Entrar" button
+- "← Voltar" link to return to email step
+- Success message: "Enviamos um código de 4 dígitos para seu email!"
+
+### Password Flow
+
+Single form with:
+- Email input
+- Password input (min 8 characters)
+- "Entrar" button
+- Hint: "Não tem senha? Use Magic Link para entrar e configure sua senha nas configurações."
+
+### Error Display
+
+Red alert box for:
+- Invalid/expired code
+- Invalid credentials
+- Network errors
+
+## Auto-Login
+
+If URL contains `?email=X&code=Y`:
+1. Extracts parameters
+2. Clears URL (no page reload)
+3. Attempts automatic login
+4. On failure, shows code step with error
+
+## API Endpoints
+
+| Action | Endpoint |
+|--------|----------|
+| Request magic link | `POST /auth/request-code` |
+| Validate code | `POST /auth/validate` |
+| Password login | `POST /auth/login` |
+
+## Business Rules
+
+1. **Code Format**: 4 numeric digits
+2. **Password Minimum**: 8 characters
+3. **Session Storage**: Token stored via `AuthContext.login()`
+4. **URL Params**: Processed once on mount, then cleared
+
+## Click Behaviors
+
+| Element | Action |
+|---------|--------|
+| "Magic Link" tab | Switches to magic link mode, resets password |
+| "Senha" tab | Switches to password mode |
+| "Enviar código" | Sends code request, advances to code step |
+| "Entrar" (code) | Validates code and logs in |
+| "Entrar" (password) | Authenticates with email/password |
+| "← Voltar" | Returns to email step, clears code |
+
+## Post-Login
+
+On successful authentication:
+1. Calls `login(token, email)` from `useAuth`
+2. App redirects to Dashboard (handled by `App.tsx`)

--- a/docs/screens/modals.md
+++ b/docs/screens/modals.md
@@ -1,0 +1,274 @@
+# Modal Components
+
+Reusable modal components used across screens.
+
+## Base Modal Component
+
+**File:** `frontend/src/components/ui/Modal.tsx`
+
+### Props
+
+| Prop | Type | Description |
+|------|------|-------------|
+| `isOpen` | boolean | Controls visibility |
+| `onClose` | function | Called on backdrop click or ESC |
+| `title` | string | Header title |
+| `subtitle` | string | Optional header subtitle |
+| `headerGradient` | string | Color variant: sage, wheat, rust, terra |
+| `size` | string | sm, md, lg, xl |
+| `footer` | ReactNode | Footer content (buttons) |
+
+### Subcomponents
+
+- `Modal.CancelButton` - Secondary style cancel button
+- `Modal.SubmitButton` - Primary style submit button with loading state
+- `Modal.DangerButton` - Destructive action button
+
+### Behaviors
+
+- ESC key closes modal
+- Backdrop click closes modal
+- Prevents body scroll when open
+
+---
+
+## TransactionEditModal
+
+**File:** `frontend/src/components/TransactionEditModal.tsx`
+
+### Purpose
+
+Edit existing transaction with full feature access.
+
+### Fields
+
+| Field | Type | Editable |
+|-------|------|----------|
+| Description | Text input | Yes |
+| Category | Dropdown | Yes |
+| Notes | Textarea | Yes |
+| Is Ignored | Toggle | Yes |
+| Planned Entry Link | Link modal | Yes |
+| Tags | Tag selector | Yes |
+
+### Actions
+
+- **Save**: Updates transaction via PATCH
+- **Create Pattern**: Opens AdvancedPatternCreator
+- **Ignore/Restore**: Toggles `is_ignored`
+- **Link/Unlink Planned Entry**: Opens TransactionPlannedEntryLinkModal
+
+### Inline Category Creation
+
+Can create new category directly in dropdown.
+
+---
+
+## TransactionCreateModal
+
+**File:** `frontend/src/components/TransactionCreateModal.tsx`
+
+### Purpose
+
+Create new manual transaction.
+
+### Fields
+
+| Field | Required | Type |
+|-------|----------|------|
+| Description | Yes | Text input |
+| Amount | Yes | Number input |
+| Date | Yes | Date picker |
+| Type | Yes | debit / credit toggle |
+| Category | No | Dropdown |
+| Notes | No | Textarea |
+
+### API
+
+`POST /financial/accounts/{accountId}/transactions`
+
+---
+
+## TransactionMatcherModal
+
+**File:** `frontend/src/components/TransactionMatcherModal.tsx`
+
+### Purpose
+
+Select a transaction to match with a planned entry.
+
+### Features
+
+- Search by description
+- Filter by category
+- Shows only transactions from the specified month
+- Currency-formatted amounts
+- Click to select
+
+### Props
+
+| Prop | Description |
+|------|-------------|
+| `plannedEntry` | The entry to match |
+| `transactions` | All available transactions |
+| `month`, `year` | Filter to specific month |
+| `onSelect` | Called with selected transaction ID |
+
+---
+
+## TransactionPlannedEntryLinkModal
+
+**File:** `frontend/src/components/TransactionPlannedEntryLinkModal.tsx`
+
+### Purpose
+
+Link a transaction to a planned entry.
+
+### Features
+
+- Lists available planned entries
+- Filter/search functionality
+- Shows current link if exists
+- Link/Unlink actions
+
+---
+
+## CategoryTransactionsModal
+
+**File:** `frontend/src/components/CategoryTransactionsModal.tsx`
+
+### Purpose
+
+View all transactions and planned entries for a specific category in a month.
+
+### Sections
+
+1. **Header**: Category name with icon/color, actual vs planned
+2. **Transactions List**: All transactions in category for month
+3. **Planned Entries List**: All planned entries in category for month
+
+### Click-Through
+
+- Transaction row → Opens TransactionEditModal (nested)
+- Planned entry row → Opens PlannedEntryForm modal (nested)
+
+---
+
+## PlannedEntryForm
+
+**File:** `frontend/src/components/PlannedEntryForm.tsx`
+
+### Purpose
+
+Create or edit planned entries.
+
+### Fields
+
+| Field | Required | Type |
+|-------|----------|------|
+| Description | Yes | Text with autocomplete |
+| Entry Type | Yes | expense / income toggle |
+| Amount | Yes* | Single or range (min/max) |
+| Expected Day | Yes* | Single or range (start/end) |
+| Category | Yes | Dropdown |
+| Is Recurrent | No | Checkbox |
+| Savings Goal Link | No | Dropdown |
+
+*Supports both single value and range modes.
+
+### Autocomplete
+
+Description field shows suggestions from past transaction descriptions.
+
+### Range Mode
+
+Toggle between:
+- Single amount → Amount field
+- Range → AmountMin, AmountMax fields
+
+Toggle between:
+- Single day → ExpectedDay field
+- Range → ExpectedDayStart, ExpectedDayEnd fields
+
+---
+
+## AdvancedPatternCreator
+
+**File:** `frontend/src/components/AdvancedPatternCreator.tsx`
+
+### Purpose
+
+Create complex regex-based patterns for auto-categorization.
+
+### Modes
+
+**Simple Mode:**
+- Description contains
+- Target category
+- Target description
+
+**Advanced Mode:**
+- Full regex pattern editor
+- Date/weekday patterns
+- Amount range conditions
+
+### Options
+
+- Link to planned entry
+- Apply retroactively to past transactions
+
+---
+
+## InviteMemberModal
+
+**File:** `frontend/src/components/InviteMemberModal.tsx`
+
+### Purpose
+
+Invite new members to organization.
+
+### Fields
+
+| Field | Required | Type |
+|-------|----------|------|
+| Email | Yes | Email input |
+| Role | Yes | Radio: user, manager, admin |
+
+### Role Descriptions
+
+Displays description of each role's capabilities.
+
+---
+
+## Modal Stack Handling
+
+Multiple modals can be open simultaneously (nested):
+
+1. CategoryTransactionsModal (parent)
+2. → TransactionEditModal (child)
+3. → → AdvancedPatternCreator (grandchild)
+
+ESC key closes innermost modal first. Each modal manages its own state.
+
+## Common Patterns
+
+### Loading State
+
+```jsx
+<Modal.SubmitButton
+  loading={isSubmitting}
+  loadingText="Salvando..."
+>
+  Salvar
+</Modal.SubmitButton>
+```
+
+### Form Validation
+
+Forms validate on submit, show error above form fields.
+
+### Success Handling
+
+1. Close modal
+2. Show success toast (via parent screen)
+3. Refresh data

--- a/docs/screens/savings-goals.md
+++ b/docs/screens/savings-goals.md
@@ -1,0 +1,139 @@
+# Savings Goals Screen
+
+**File:** `frontend/src/components/SavingsGoalsPage.tsx`
+
+## Purpose
+
+Track long-term savings goals with contributions, progress visualization, and completion management.
+
+## What the User Sees
+
+### Header
+
+- Title: "Metas de Poupança" with target icon
+- Subtitle: "Acompanhe suas metas de economia e investimento"
+- "+ Nova Meta" button
+
+### Summary Cards
+
+Three cards (only shown if goals exist):
+- **Total das Metas**: Sum of all target amounts
+- **Total Acumulado**: Sum of current amounts (green)
+- **Progresso Geral**: Overall percentage with progress bar
+
+### Filters
+
+- **Tipo dropdown**: Todos, Reserva, Investimento
+- **Checkbox**: "Mostrar concluídos"
+
+### Goals Grid
+
+Grid of `SavingsGoalCard` components showing:
+- Goal icon and name
+- Type badge (Reserva / Investimento)
+- Progress bar with custom color
+- Current amount / Target amount
+- Remaining amount
+- Due date (if set)
+- Dropdown actions menu
+
+### Empty State
+
+When no goals match filters:
+- Target icon placeholder
+- "Nenhuma meta encontrada"
+- "Criar Meta" button
+
+## Goal Types
+
+| Type | Label | Description |
+|------|-------|-------------|
+| `reserva` | Reserva | Date-bound goals (due date required) |
+| `investimento` | Investimento | Open-ended savings (due date optional) |
+
+## Data Sources
+
+| Data | API Function |
+|------|--------------|
+| Goals list | `listSavingsGoals()` |
+| Goal progress | `getSavingsGoalProgress()` |
+| Create | `createSavingsGoal()` |
+| Update | `updateSavingsGoal()` |
+| Delete | `deleteSavingsGoal()` |
+| Complete | `completeSavingsGoal()` |
+| Reopen | `reopenSavingsGoal()` |
+| Contribute | `addContribution()` |
+
+## Business Rules
+
+### Goal Creation
+
+Required fields:
+- Name
+- Goal type
+- Target amount (> 0)
+- Due date (required for `reserva`, optional for `investimento`)
+
+### Progress Calculation
+
+- `current_amount`: Sum of all contributions
+- `progress`: `(current_amount / target_amount) * 100`
+- Overall progress: Sum of all current / Sum of all targets
+
+### Contributions
+
+- Can be positive (deposit) or negative (withdrawal)
+- No minimum/maximum validation
+- Updates `current_amount` on goal
+
+### Completion
+
+- User manually marks as complete
+- Completed goals hidden by default (toggle filter)
+- Can reopen completed goals
+
+## Click Behaviors
+
+| Element | Action |
+|---------|--------|
+| "+ Nova Meta" | Opens create form modal |
+| Goal card actions → Edit | Opens edit form modal |
+| Goal card actions → Delete | Confirm dialog → `deleteSavingsGoal()` |
+| Goal card actions → Complete | Confirm dialog → `completeSavingsGoal()` |
+| Goal card actions → Reopen | `reopenSavingsGoal()` |
+| Goal card actions → Add contribution | Opens contribution modal |
+
+## Modals
+
+### Create/Edit Goal Modal
+
+Form fields:
+- **Nome da Meta** (required)
+- **Tipo de Meta** (only for create): radio cards with descriptions
+- **Valor da Meta** (required): R$ input
+- **Data Limite**: date picker (required for reserva)
+- **Ícone**: 20+ emoji options
+- **Cor da Barra de Progresso**: 12 color swatches
+- **Observações**: textarea
+
+### Contribution Modal
+
+Simple form:
+- Goal name display
+- Amount input (positive or negative)
+- Hint: "Use valores positivos para adicionar ou negativos para subtrair"
+
+## Visual Customization
+
+### Icons (GOAL_ICONS)
+
+Available emojis: 🎯 💰 🏠 🚗 ✈️ 📚 💻 🎓 💍 👶 🏖️ 🎸 📱 🏋️ 🎨 🌱 ⭐ 🔒 💎 🎁
+
+### Colors (GOAL_COLORS)
+
+12 hex colors for progress bar customization.
+
+## Links to Other Features
+
+- **Planned Entries**: Goals can be linked to planned entries (see [budgets.md](./budgets.md))
+- **Dashboard**: Goal progress could be shown (not currently implemented)

--- a/docs/screens/settings.md
+++ b/docs/screens/settings.md
@@ -1,0 +1,194 @@
+# Settings Screen
+
+**File:** `frontend/src/components/SettingsPage.tsx`
+
+## Purpose
+
+Central configuration hub with five tabs for managing account, categories, patterns, tags, and organization.
+
+## Tab Structure
+
+| Tab ID | Label | Component |
+|--------|-------|-----------|
+| `conta` | Sua Conta | `AccountSettings.tsx` |
+| `categorias` | Categorias | `CategoryManager.tsx` |
+| `padroes` | Padrões | `PatternManager.tsx` |
+| `tags` | Tags | `TagManager.tsx` |
+| `organizacao` | Organização | `OrganizationSettings.tsx` |
+
+## Tab Navigation
+
+- Tabs displayed as horizontal buttons with icons
+- Active tab has wheat-colored underline
+- `initialTab` prop allows deep linking from avatar menu
+
+---
+
+## Account Settings Tab
+
+**File:** `frontend/src/components/AccountSettings.tsx`
+
+### What the User Sees
+
+- User email display
+- Password management section
+- Email import address (copy to clipboard)
+- Logout button
+
+### Password Management
+
+Two states:
+
+**No password set:**
+- "Definir Senha" form
+- New password (min 8 chars)
+- Confirm password
+- "Salvar Senha" button
+
+**Password exists:**
+- "Alterar Senha" form
+- Current password
+- New password
+- Confirm password
+- "Alterar Senha" button
+- Toggle to show/hide passwords
+
+### Email Import
+
+- Shows organization's import email address
+- "Copiar" button copies to clipboard
+- Used for forwarding OFX attachments
+
+### Logout
+
+- "Sair" button with confirmation
+- Calls `logout()` from `AuthContext`
+
+---
+
+## Categories Tab
+
+**File:** `frontend/src/components/CategoryManager.tsx`
+
+### What the User Sees
+
+- "+ Nova Categoria" button
+- Grid of category cards with icon, name, color
+- Edit/Delete actions per category
+
+### Create/Edit Category Modal
+
+Fields:
+- **Nome** (required)
+- **Ícone**: 40+ emoji grid picker
+- **Cor**: 30+ color swatches
+
+### Business Rules
+
+- Categories used for transaction classification
+- Deleting a category removes it from linked transactions
+- Each category has type: `expense` or `income`
+
+---
+
+## Patterns Tab
+
+**File:** `frontend/src/components/PatternManager.tsx`
+
+### What the User Sees
+
+- "+ Novo Padrão" button
+- List of patterns with:
+  - Description pattern (regex)
+  - Target category
+  - Active/Inactive toggle
+  - Edit/Delete actions
+
+### Pattern Features
+
+- Match by description (regex)
+- Match by date/weekday
+- Match by amount range
+- Set target description and category
+- Link to planned entry
+- Apply retroactively to past transactions
+
+### Related Component
+
+Uses `AdvancedPatternCreator.tsx` for pattern form.
+
+---
+
+## Tags Tab
+
+**File:** `frontend/src/components/TagManager.tsx`
+
+### What the User Sees
+
+- "+ Nova Tag" button
+- Grid of tag cards with icon, name, color
+- Edit/Delete actions per tag
+
+### Tag Features
+
+- Icon selection (20+ options)
+- Color customization
+- Applied to individual transactions via TransactionEditModal
+
+---
+
+## Organization Tab
+
+**File:** `frontend/src/components/OrganizationSettings.tsx`
+
+### What the User Sees
+
+- Organization name (editable by admin)
+- Members list with roles
+- Pending invitations list
+- "+ Convidar Membro" button
+
+### Member Roles
+
+| Role | Capabilities |
+|------|--------------|
+| `admin` | Full access, manage members, edit org |
+| `manager` | Manage transactions and budgets |
+| `user` | View and basic operations |
+
+### Invite Flow
+
+1. Click "+ Convidar Membro"
+2. Enter email and select role
+3. Invitation sent via email
+4. Shows in "Convites Pendentes" until accepted/cancelled
+
+### Related Component
+
+Uses `InviteMemberModal.tsx` for invitation form.
+
+---
+
+## Click Behaviors Summary
+
+| Tab | Element | Action |
+|-----|---------|--------|
+| Conta | "Sair" | Logout with confirmation |
+| Conta | "Copiar" | Copy email to clipboard |
+| Categorias | Category card | Opens edit modal |
+| Categorias | Delete icon | Deletes category |
+| Padrões | Pattern row | Opens edit modal |
+| Padrões | Toggle switch | Enables/disables pattern |
+| Tags | Tag card | Opens edit modal |
+| Organização | Member row | View only |
+| Organização | "Cancelar" on invite | Cancels pending invite |
+
+## Data Sources
+
+| Tab | API Endpoints |
+|-----|---------------|
+| Conta | User data from context, password change API |
+| Categorias | `GET/POST/PATCH/DELETE /financial/categories` |
+| Padrões | Advanced patterns API |
+| Tags | `GET/POST/PATCH/DELETE /financial/tags` |
+| Organização | Organization and invitations API |

--- a/docs/screens/transactions.md
+++ b/docs/screens/transactions.md
@@ -1,0 +1,137 @@
+# Transactions Screen
+
+**File:** `frontend/src/components/TransactionList.tsx`
+
+## Purpose
+
+View, manage, and import financial transactions. Supports OFX file import, bulk operations, and filtering.
+
+## What the User Sees
+
+### Month Navigation Header
+
+Same pattern as Budgets screen:
+- Previous/Next month arrows
+- Month name and year
+- Transaction count (filtered / total)
+- "Mês atual" badge
+- "Hoje" button
+- Action buttons: "Nova Transação", "Importar OFX"
+
+### Filters Bar
+
+Inline checkboxes:
+- **Sem categoria**: Show only uncategorized transactions
+- **Ocultar ignoradas**: Hide ignored transactions
+- **Selecionar todas / Desmarcar todas**: Toggle bulk selection
+
+### Bulk Actions Bar
+
+Appears when transactions are selected:
+- Selection count with clear button
+- **Definir categoria**: Dropdown to set category on all selected
+- **Ignorar**: Mark selected as ignored
+- **Restaurar**: Unmark selected as ignored
+
+### Summary Cards
+
+Three cards for current month:
+- **Receitas**: Sum of credit transactions (green)
+- **Despesas**: Sum of debit transactions (red)
+- **Saldo**: Income - Expenses (green if positive, red if negative)
+
+### Transaction List
+
+**Mobile (card view)**:
+- Checkbox, description, amount
+- Date, category badge, ignored badge
+- Tap card to edit
+
+**Desktop (table view)**:
+- Checkbox column with select-all header
+- Date | Description | Amount | Category columns
+- Hover highlights row
+- Click row to edit
+
+### Drag & Drop Zone
+
+Full-screen overlay when dragging files:
+- "Solte os arquivos OFX aqui"
+- Processes multiple files
+
+### Success/Error Messages
+
+Toast-style alerts for:
+- Import results: "X transações importadas (Y duplicadas)"
+- Bulk action results: "X transações atualizadas!"
+- Errors: Red alert with retry info
+
+## Data Sources
+
+| Data | Endpoint |
+|------|----------|
+| Accounts | `GET /financial/accounts` |
+| Categories | `GET /financial/categories` |
+| Transactions | `GET /financial/accounts/{id}/transactions` |
+
+## Business Rules
+
+### Month Filtering
+
+Transactions filtered by `selectedMonth` and `selectedYear` from `useSelectedMonth` hook.
+
+### Totals Calculation
+
+- Only non-ignored transactions counted
+- Credits → Income
+- Debits → Expenses
+- Balance = Income - Expenses
+
+### OFX Import
+
+1. Files dropped or selected via input
+2. Only `.ofx` files processed
+3. Each file uploaded to `POST /accounts/{id}/transactions/import`
+4. Response includes `ImportedCount` and `DuplicateCount`
+5. Transaction list refreshed after import
+
+### Bulk Operations
+
+All bulk operations call `PATCH /accounts/{accountId}/transactions/{id}`:
+- Category change: `{ category_id: number | null }`
+- Ignore/Restore: `{ is_ignored: boolean }`
+
+### Filter Persistence
+
+Filters stored in `localStorage` via `usePersistedFilters` hook.
+
+## Click Behaviors
+
+| Element | Action |
+|---------|--------|
+| Transaction row/card | Opens TransactionEditModal |
+| Checkbox | Toggles selection (stops propagation) |
+| "Nova Transação" | Opens TransactionCreateModal |
+| "Importar OFX" | Opens file picker |
+| "Selecionar todas" | Selects all visible transactions |
+| "Definir categoria" dropdown item | Sets category on selected |
+| "Ignorar" | Marks selected as ignored |
+| "Restaurar" | Unmarks selected as ignored |
+
+## Modals
+
+### TransactionEditModal
+
+See [modals.md](./modals.md#transactioneditmodal)
+
+### TransactionCreateModal
+
+See [modals.md](./modals.md#transactioncreatemodal)
+
+## Links to Other Features
+
+- **Categories**: Used for classification
+- **Budgets**: Transactions counted in actual spending
+- **Planned Entries**: Can be linked via edit modal
+- **Patterns**: Can create patterns from transaction
+- **Tags**: Can add tags to transactions


### PR DESCRIPTION
Document all application screens with business rules, click behaviors,
and cross-feature links:

- Dashboard: financial overview and alerts
- Transactions: list, import, bulk operations
- Budgets: category budgets and planned entries
- Savings Goals: long-term savings tracking
- Settings: 5 tabs (account, categories, patterns, tags, org)
- Login: magic link and password auth
- Modals: reusable modal component documentation

Each doc covers what users see, data sources, business rules,
and click behaviors. References other docs/files where applicable.