### PR TITLE
feat: similarity-based auto-categorization for OFX imports

### DIFF
--- a/backend/internal/application/financial/dto.go
+++ b/backend/internal/application/financial/dto.go
@@ -104,6 +104,10 @@ type Transaction struct {
 	IsClassified         bool            `json:"is_classified"`
 	ClassificationRuleID *int            `json:"classification_rule_id,omitempty"`
 	IsIgnored            bool            `json:"is_ignored"`
+	ClassifiedBy         *string         `json:"classified_by,omitempty"`           // manual, pattern, planned_entry, similarity
+	SuggestedCategoryID  *int            `json:"suggested_category_id,omitempty"`   // Suggestion for ambiguous/low-confidence
+	SuggestedDescription *string         `json:"suggested_description,omitempty"`   // Best description from similar past transactions
+	SuggestionConfidence *float64        `json:"suggestion_confidence,omitempty"`   // 0.0 to 1.0
 	Notes                *string         `json:"notes,omitempty"`
 	Tags                 []string        `json:"tags"`
 	CreatedAt            time.Time       `json:"created_at"`
@@ -128,6 +132,10 @@ func (t Transaction) FromModel(model *TransactionModel) Transaction {
 		IsClassified:         model.IsClassified,
 		ClassificationRuleID: model.ClassificationRuleID,
 		IsIgnored:            model.IsIgnored,
+		ClassifiedBy:         model.ClassifiedBy,
+		SuggestedCategoryID:  model.SuggestedCategoryID,
+		SuggestedDescription: model.SuggestedDescription,
+		SuggestionConfidence: model.SuggestionConfidence,
 		Notes:                model.Notes,
 		Tags:                 model.Tags,
 		CreatedAt:            model.CreatedAt,

--- a/backend/internal/application/financial/models.go
+++ b/backend/internal/application/financial/models.go
@@ -77,6 +77,12 @@ type TransactionModel struct {
 	// Savings Goal (orthogonal to category)
 	SavingsGoalID *int `db:"savings_goal_id"`
 
+	// Similarity classification
+	ClassifiedBy         *string  `db:"classified_by"`           // manual, pattern, planned_entry, similarity
+	SuggestedCategoryID  *int     `db:"suggested_category_id"`   // Best category suggestion (when ambiguous or low confidence)
+	SuggestedDescription *string  `db:"suggested_description"`   // Best description from similar past transactions
+	SuggestionConfidence *float64 `db:"suggestion_confidence"`   // 0.0 to 1.0
+
 	// Metadata
 	Notes *string        `db:"notes"`
 	Tags  pq.StringArray `db:"tags"`

--- a/backend/internal/application/financial/repository.go
+++ b/backend/internal/application/financial/repository.go
@@ -1783,11 +1783,13 @@ const removePlannedEntryQuery = `
 	DELETE FROM planned_entries
 	WHERE planned_entry_id = $1
 		AND user_id = $2
-		AND organization_id = $3;
+		AND organization_id = $3
+	RETURNING planned_entry_id;
 `
 
 func (r *repository) RemovePlannedEntry(ctx context.Context, params removePlannedEntryParams) error {
-	return r.db.Run(ctx, removePlannedEntryQuery,
+	var deletedID int
+	return r.db.Query(ctx, &deletedID, removePlannedEntryQuery,
 		params.PlannedEntryID, params.UserID, params.OrganizationID)
 }
 

--- a/backend/internal/application/financial/repository.go
+++ b/backend/internal/application/financial/repository.go
@@ -29,6 +29,9 @@ type Repository interface {
 	FetchTransactionsByMonth(ctx context.Context, params fetchTransactionsByMonthParams) ([]TransactionModel, error)
 	FetchUncategorizedTransactions(ctx context.Context, params fetchUncategorizedTransactionsParams) ([]TransactionModel, error)
 	FetchTransactionsForPatternMatching(ctx context.Context, params fetchTransactionsForPatternMatchingParams) ([]TransactionModel, error)
+	FetchSimilarCategoryDistribution(ctx context.Context, params fetchSimilarCategoryDistributionParams) ([]CategoryDistributionModel, error)
+	SetTransactionSimilarityResult(ctx context.Context, params setTransactionSimilarityResultParams) error
+	FetchTransactionsNeedingReview(ctx context.Context, params fetchTransactionsNeedingReviewParams) ([]TransactionModel, error)
 	InsertTransaction(ctx context.Context, params insertTransactionParams) (TransactionModel, error)
 	BulkInsertTransactions(ctx context.Context, params bulkInsertTransactionsParams) ([]TransactionModel, error)
 	ModifyTransaction(ctx context.Context, params modifyTransactionParams) (TransactionModel, error)
@@ -475,6 +478,10 @@ const fetchTransactionsQuery = `
 		t.classification_rule_id,
 		t.is_ignored,
 		t.savings_goal_id,
+		t.classified_by,
+		t.suggested_category_id,
+		t.suggested_description,
+		t.suggestion_confidence,
 		t.notes,
 		t.tags
 	FROM transactions t
@@ -521,6 +528,10 @@ const fetchTransactionByIDQuery = `
 		t.classification_rule_id,
 		t.is_ignored,
 		t.savings_goal_id,
+		t.classified_by,
+		t.suggested_category_id,
+		t.suggested_description,
+		t.suggestion_confidence,
 		t.notes,
 		t.tags
 	FROM transactions t
@@ -565,6 +576,10 @@ const fetchUncategorizedTransactionsQuery = `
 		t.classification_rule_id,
 		t.is_ignored,
 		t.savings_goal_id,
+		t.classified_by,
+		t.suggested_category_id,
+		t.suggested_description,
+		t.suggestion_confidence,
 		t.notes,
 		t.tags
 	FROM transactions t
@@ -611,6 +626,10 @@ const fetchTransactionsForPatternMatchingQuery = `
 		t.classification_rule_id,
 		t.is_ignored,
 		t.savings_goal_id,
+		t.classified_by,
+		t.suggested_category_id,
+		t.suggested_description,
+		t.suggestion_confidence,
 		t.notes,
 		t.tags
 	FROM transactions t
@@ -656,6 +675,10 @@ const fetchTransactionsByMonthQuery = `
 		t.classification_rule_id,
 		t.is_ignored,
 		t.savings_goal_id,
+		t.classified_by,
+		t.suggested_category_id,
+		t.suggested_description,
+		t.suggestion_confidence,
 		t.notes,
 		t.tags
 	FROM transactions t
@@ -712,7 +735,8 @@ const insertTransactionQuery = `
 		updated_at = NOW()
 	RETURNING transaction_id, created_at, updated_at, account_id, category_id, description, original_description, amount,
 			  transaction_date, transaction_type, ofx_fitid, ofx_check_number, ofx_memo, raw_ofx_data,
-			  is_classified, classification_rule_id, is_ignored, notes, tags;
+			  is_classified, classification_rule_id, is_ignored, savings_goal_id,
+			  classified_by, suggested_category_id, suggested_description, suggestion_confidence, notes, tags;
 `
 
 func (r *repository) InsertTransaction(ctx context.Context, params insertTransactionParams) (TransactionModel, error) {
@@ -768,6 +792,11 @@ const modifyTransactionQuery = `
 		amount = COALESCE($7, t.amount),
 		notes = COALESCE($8, t.notes),
 		is_ignored = COALESCE($9, t.is_ignored),
+		-- When user explicitly sets a category, mark as manual and clear suggestion
+		classified_by = CASE WHEN $4 IS NOT NULL THEN 'manual' ELSE t.classified_by END,
+		suggested_category_id = CASE WHEN $4 IS NOT NULL THEN NULL ELSE t.suggested_category_id END,
+		suggested_description = CASE WHEN $4 IS NOT NULL THEN NULL ELSE t.suggested_description END,
+		suggestion_confidence = CASE WHEN $4 IS NOT NULL THEN NULL ELSE t.suggestion_confidence END,
 		updated_at = NOW()
 	FROM accounts a
 	WHERE t.transaction_id = $1
@@ -777,7 +806,8 @@ const modifyTransactionQuery = `
 	RETURNING t.transaction_id, t.created_at, t.updated_at, t.account_id, t.category_id, t.description,
 			  t.original_description, t.amount, t.transaction_date, t.transaction_type, t.ofx_fitid,
 			  t.ofx_check_number, t.ofx_memo, t.raw_ofx_data, t.is_classified, t.classification_rule_id,
-			  t.is_ignored, t.savings_goal_id, t.notes, t.tags;
+			  t.is_ignored, t.savings_goal_id, t.classified_by, t.suggested_category_id,
+			  t.suggested_description, t.suggestion_confidence, t.notes, t.tags;
 `
 
 func (r *repository) ModifyTransaction(ctx context.Context, params modifyTransactionParams) (TransactionModel, error) {
@@ -810,6 +840,151 @@ const removeTransactionQuery = `
 func (r *repository) RemoveTransaction(ctx context.Context, params removeTransactionParams) error {
 	err := r.db.Run(ctx, removeTransactionQuery, params.TransactionID, params.UserID, params.OrganizationID)
 	return err
+}
+
+// ============================================================================
+// Similarity Classification
+// ============================================================================
+
+// CategoryDistributionModel holds the result of a similarity category lookup.
+// Each row represents one category that similar descriptions have been mapped to.
+type CategoryDistributionModel struct {
+	CategoryID           int     `db:"category_id"`
+	SuggestedDescription *string `db:"suggested_description"` // Most common user-edited description for this category
+	AvgSimilarity        float64 `db:"avg_similarity"`
+	Frequency            int     `db:"frequency"`
+	Score                float64 `db:"score"`
+}
+
+type fetchSimilarCategoryDistributionParams struct {
+	OriginalDescription string
+	OrganizationID      int
+	SimilarityThreshold float64
+	LookbackMonths      int
+}
+
+const fetchSimilarCategoryDistributionQuery = `
+	-- financial.fetchSimilarCategoryDistributionQuery
+	-- Returns category distribution for descriptions similar to the input,
+	-- ordered by frequency-weighted similarity score.
+	-- Used to detect ambiguity (2+ rows) vs. unambiguous (1 row) classifications.
+	SELECT
+		t.category_id,
+		MODE() WITHIN GROUP (ORDER BY t.description) AS suggested_description,
+		AVG(similarity(t.original_description, $1))::FLOAT8 AS avg_similarity,
+		COUNT(*)::INT AS frequency,
+		(AVG(similarity(t.original_description, $1)) * LN(COUNT(*) + 1))::FLOAT8 AS score
+	FROM transactions t
+	INNER JOIN accounts a ON a.account_id = t.account_id
+	WHERE a.organization_id = $2
+		AND t.category_id IS NOT NULL
+		AND t.is_ignored = false
+		AND t.original_description IS NOT NULL
+		AND t.transaction_date >= NOW() - make_interval(months => $3::INT)
+		AND similarity(t.original_description, $1) > $4
+	GROUP BY t.category_id
+	ORDER BY score DESC;
+`
+
+func (r *repository) FetchSimilarCategoryDistribution(ctx context.Context, params fetchSimilarCategoryDistributionParams) ([]CategoryDistributionModel, error) {
+	var result []CategoryDistributionModel
+	err := r.db.Query(ctx, &result, fetchSimilarCategoryDistributionQuery,
+		params.OriginalDescription, params.OrganizationID, params.LookbackMonths, params.SimilarityThreshold)
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+type setTransactionSimilarityResultParams struct {
+	TransactionID        int
+	CategoryID           *int    // Set when auto-classifying; nil for suggestion-only
+	Description          *string // Set when auto-classifying with suggested description
+	IsClassified         bool    // true when auto-classifying
+	ClassifiedBy         *string // "similarity" when auto-classifying; nil for suggestion-only
+	SuggestedCategoryID  *int    // Best suggestion (set for both ambiguous and low-confidence)
+	SuggestedDescription *string // Best description from similar past transactions
+	SuggestionConfidence *float64
+}
+
+const setTransactionSimilarityResultQuery = `
+	-- financial.setTransactionSimilarityResultQuery
+	UPDATE transactions
+	SET category_id = COALESCE($2, category_id),
+		description = COALESCE($3, description),
+		is_classified = CASE WHEN $4 THEN true ELSE is_classified END,
+		classified_by = COALESCE($5, classified_by),
+		suggested_category_id = $6,
+		suggested_description = $7,
+		suggestion_confidence = $8,
+		updated_at = NOW()
+	WHERE transaction_id = $1;
+`
+
+func (r *repository) SetTransactionSimilarityResult(ctx context.Context, params setTransactionSimilarityResultParams) error {
+	return r.db.Run(ctx, setTransactionSimilarityResultQuery,
+		params.TransactionID, params.CategoryID, params.Description,
+		params.IsClassified, params.ClassifiedBy,
+		params.SuggestedCategoryID, params.SuggestedDescription, params.SuggestionConfidence)
+}
+
+type fetchTransactionsNeedingReviewParams struct {
+	OrganizationID int
+	Month          int
+	Year           int
+}
+
+const fetchTransactionsNeedingReviewQuery = `
+	-- financial.fetchTransactionsNeedingReviewQuery
+	-- Returns transactions that need user review:
+	-- 1. Auto-classified by similarity (user should confirm/fix)
+	-- 2. Has a suggestion but not yet categorized (user should accept/change)
+	SELECT
+		t.transaction_id,
+		t.created_at,
+		t.updated_at,
+		t.account_id,
+		t.category_id,
+		t.description,
+		t.original_description,
+		t.amount,
+		t.transaction_date,
+		t.transaction_type,
+		t.ofx_fitid,
+		t.ofx_check_number,
+		t.ofx_memo,
+		t.raw_ofx_data,
+		t.is_classified,
+		t.classification_rule_id,
+		t.is_ignored,
+		t.savings_goal_id,
+		t.classified_by,
+		t.suggested_category_id,
+		t.suggested_description,
+		t.suggestion_confidence,
+		t.notes,
+		t.tags
+	FROM transactions t
+	INNER JOIN accounts a ON a.account_id = t.account_id
+	WHERE a.organization_id = $1
+		AND t.is_ignored = false
+		AND EXTRACT(MONTH FROM t.transaction_date) = $2
+		AND EXTRACT(YEAR FROM t.transaction_date) = $3
+		AND (
+			t.classified_by = 'similarity'
+			OR (t.suggested_category_id IS NOT NULL AND t.category_id IS NULL)
+		)
+	ORDER BY t.transaction_date DESC, t.created_at DESC;
+`
+
+func (r *repository) FetchTransactionsNeedingReview(ctx context.Context, params fetchTransactionsNeedingReviewParams) ([]TransactionModel, error) {
+	var result []TransactionModel
+	err := r.db.Query(ctx, &result, fetchTransactionsNeedingReviewQuery,
+		params.OrganizationID, params.Month, params.Year)
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
 }
 
 // ============================================================================
@@ -2734,6 +2909,10 @@ const fetchGoalContributionsQuery = `
 		t.classification_rule_id,
 		t.is_ignored,
 		t.savings_goal_id,
+		t.classified_by,
+		t.suggested_category_id,
+		t.suggested_description,
+		t.suggestion_confidence,
 		t.notes,
 		t.tags
 	FROM transactions t

--- a/backend/internal/application/financial/service.go
+++ b/backend/internal/application/financial/service.go
@@ -1647,6 +1647,8 @@ type DeletePlannedEntryInput struct {
 	OrganizationID int
 }
 
+var ErrPlannedEntryNotFound = fmt.Errorf("planned entry not found")
+
 func (s *service) DeletePlannedEntry(ctx context.Context, params DeletePlannedEntryInput) error {
 	err := s.Repository.RemovePlannedEntry(ctx, removePlannedEntryParams{
 		PlannedEntryID: params.PlannedEntryID,
@@ -1654,6 +1656,9 @@ func (s *service) DeletePlannedEntry(ctx context.Context, params DeletePlannedEn
 		OrganizationID: params.OrganizationID,
 	})
 	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return ErrPlannedEntryNotFound
+		}
 		return errors.Wrap(err, "failed to delete planned entry")
 	}
 

--- a/backend/internal/application/financial/service.go
+++ b/backend/internal/application/financial/service.go
@@ -145,6 +145,10 @@ type Service interface {
 	// Planned Entry Tags
 	GetPlannedEntryTags(ctx context.Context, input GetPlannedEntryTagsInput) ([]Tag, error)
 	SetPlannedEntryTags(ctx context.Context, input SetPlannedEntryTagsInput) error
+
+	// Similarity Classification
+	SuggestCategoryForTransaction(ctx context.Context, input SuggestCategoryInput) (SuggestCategoryOutput, error)
+	GetTransactionsNeedingReview(ctx context.Context, input GetTransactionsNeedingReviewInput) ([]Transaction, error)
 }
 
 type service struct {
@@ -541,10 +545,13 @@ type ImportOFXInput struct {
 }
 
 type ImportOFXOutput struct {
-	ImportedCount  int
-	DuplicateCount int
-	ErrorCount     int
-	Transactions   []Transaction
+	ImportedCount          int
+	DuplicateCount         int
+	ErrorCount             int
+	PatternMatchedCount    int
+	SimilarityMatchedCount int
+	SuggestedCount         int
+	Transactions           []Transaction
 }
 
 // ImportTransactionsFromOFX parses OFX data and imports transactions
@@ -614,8 +621,9 @@ func (s *service) ImportTransactionsFromOFX(ctx context.Context, params ImportOF
 	importedCount := len(inserted)
 	duplicateCount := len(ofxTransactions) - importedCount
 
-	// Auto-match imported transactions using advanced patterns (regex-based)
-	matchedCount := 0
+	// Phase 1: Auto-match imported transactions using patterns (regex-based)
+	patternMatchedCount := 0
+	patternMatchedIDs := make(map[int]bool)
 	for _, tx := range inserted {
 		matched, err := s.ApplyPatternsToTransaction(ctx, ApplyPatternsToTransactionInput{
 			TransactionID:  tx.TransactionID,
@@ -630,7 +638,75 @@ func (s *service) ImportTransactionsFromOFX(ctx context.Context, params ImportOF
 			continue
 		}
 		if matched {
-			matchedCount++
+			patternMatchedCount++
+			patternMatchedIDs[tx.TransactionID] = true
+		}
+	}
+
+	// Phase 2: Similarity-based classification for transactions not matched by patterns
+	similarityMatchedCount := 0
+	suggestedCount := 0
+	for _, tx := range inserted {
+		if patternMatchedIDs[tx.TransactionID] {
+			continue // already classified by pattern
+		}
+		if tx.OriginalDescription == nil || *tx.OriginalDescription == "" {
+			continue // manual transactions have no original_description
+		}
+
+		suggestion, err := s.SuggestCategoryForTransaction(ctx, SuggestCategoryInput{
+			OriginalDescription: *tx.OriginalDescription,
+			OrganizationID:      params.OrganizationID,
+		})
+		if err != nil {
+			s.logger.Warn(ctx, "Similarity suggestion failed",
+				"transaction_id", tx.TransactionID,
+				"error", err.Error(),
+			)
+			continue
+		}
+
+		if suggestion.CategoryID == nil {
+			continue // no similar history found
+		}
+
+		if !suggestion.IsAmbiguous && suggestion.Confidence >= SimilarityAutoClassifyMinScore {
+			// Unambiguous + high confidence → auto-classify (category + description)
+			classifiedBy := ClassifiedBySimilarity
+			err = s.Repository.SetTransactionSimilarityResult(ctx, setTransactionSimilarityResultParams{
+				TransactionID:        tx.TransactionID,
+				CategoryID:           suggestion.CategoryID,
+				Description:          suggestion.SuggestedDescription,
+				IsClassified:         true,
+				ClassifiedBy:         &classifiedBy,
+				SuggestedCategoryID:  suggestion.CategoryID,
+				SuggestedDescription: suggestion.SuggestedDescription,
+				SuggestionConfidence: &suggestion.Confidence,
+			})
+			if err != nil {
+				s.logger.Warn(ctx, "Failed to auto-classify transaction",
+					"transaction_id", tx.TransactionID,
+					"error", err.Error(),
+				)
+				continue
+			}
+			similarityMatchedCount++
+		} else {
+			// Ambiguous or low confidence → store suggestion only
+			err = s.Repository.SetTransactionSimilarityResult(ctx, setTransactionSimilarityResultParams{
+				TransactionID:        tx.TransactionID,
+				SuggestedCategoryID:  suggestion.CategoryID,
+				SuggestedDescription: suggestion.SuggestedDescription,
+				SuggestionConfidence: &suggestion.Confidence,
+			})
+			if err != nil {
+				s.logger.Warn(ctx, "Failed to store category suggestion",
+					"transaction_id", tx.TransactionID,
+					"error", err.Error(),
+				)
+				continue
+			}
+			suggestedCount++
 		}
 	}
 
@@ -650,15 +726,20 @@ func (s *service) ImportTransactionsFromOFX(ctx context.Context, params ImportOF
 		"total_parsed", len(ofxTransactions),
 		"imported", importedCount,
 		"duplicates", duplicateCount,
-		"pattern_matched", matchedCount,
+		"pattern_matched", patternMatchedCount,
+		"similarity_matched", similarityMatchedCount,
+		"suggested", suggestedCount,
 		"duration_seconds", importDuration,
 	)
 
 	return ImportOFXOutput{
-		ImportedCount:  importedCount,
-		DuplicateCount: duplicateCount,
-		ErrorCount:     0,
-		Transactions:   Transactions{}.FromModel(inserted),
+		ImportedCount:          importedCount,
+		DuplicateCount:         duplicateCount,
+		ErrorCount:             0,
+		PatternMatchedCount:    patternMatchedCount,
+		SimilarityMatchedCount: similarityMatchedCount,
+		SuggestedCount:         suggestedCount,
+		Transactions:           Transactions{}.FromModel(inserted),
 	}, nil
 }
 
@@ -2699,4 +2780,99 @@ func (s *service) SetPlannedEntryTags(ctx context.Context, input SetPlannedEntry
 		PlannedEntryID: input.PlannedEntryID,
 		TagIDs:         input.TagIDs,
 	})
+}
+
+// ============================================================================
+// Similarity Classification
+// ============================================================================
+
+const (
+	// SimilarityThreshold is the minimum trigram similarity to consider descriptions as related
+	SimilarityThreshold = 0.6
+	// SimilarityLookbackMonths is how far back to look for categorized transactions
+	SimilarityLookbackMonths = 3
+	// SimilarityAutoClassifyMinScore is the minimum score to auto-classify without review
+	SimilarityAutoClassifyMinScore = 0.7
+	// ClassifiedBySimilarity is the value for classified_by when auto-classified
+	ClassifiedBySimilarity = "similarity"
+)
+
+type SuggestCategoryInput struct {
+	OriginalDescription string
+	OrganizationID      int
+}
+
+type SuggestCategoryOutput struct {
+	CategoryID           *int    // Best category (nil if no history found)
+	SuggestedDescription *string // Most common user-edited description for similar transactions
+	Confidence           float64 // Normalized score (0.0 - 1.0)
+	IsAmbiguous          bool    // true if 2+ categories found for similar descriptions
+}
+
+// SuggestCategoryForTransaction analyzes past categorized transactions to find
+// the best category match for a description. Returns ambiguity information
+// so the caller can decide whether to auto-classify or suggest.
+func (s *service) SuggestCategoryForTransaction(ctx context.Context, input SuggestCategoryInput) (SuggestCategoryOutput, error) {
+	distribution, err := s.Repository.FetchSimilarCategoryDistribution(ctx, fetchSimilarCategoryDistributionParams{
+		OriginalDescription: input.OriginalDescription,
+		OrganizationID:      input.OrganizationID,
+		SimilarityThreshold: SimilarityThreshold,
+		LookbackMonths:      SimilarityLookbackMonths,
+	})
+	if err != nil {
+		return SuggestCategoryOutput{}, fmt.Errorf("fetch similar categories: %w", err)
+	}
+
+	// No history — unknown
+	if len(distribution) == 0 {
+		return SuggestCategoryOutput{}, nil
+	}
+
+	best := distribution[0] // Sorted by score DESC
+
+	// Normalize score to 0-1 range.
+	// The raw score is AVG(similarity) * LN(frequency + 1).
+	// Max theoretical: similarity=1.0 * LN(inf) → unbounded, but practically
+	// capped around 3-4 for realistic frequencies.
+	// We use the avg_similarity as the primary confidence signal since it's
+	// already in [0,1], weighted slightly by whether we have frequency backing.
+	confidence := best.AvgSimilarity
+	if best.Frequency > 1 {
+		// Small bonus for repeated matches, capped at 1.0
+		bonus := 0.05 * float64(best.Frequency-1)
+		if bonus > 0.15 {
+			bonus = 0.15
+		}
+		confidence += bonus
+		if confidence > 1.0 {
+			confidence = 1.0
+		}
+	}
+
+	return SuggestCategoryOutput{
+		CategoryID:           &best.CategoryID,
+		SuggestedDescription: best.SuggestedDescription,
+		Confidence:           confidence,
+		IsAmbiguous:          len(distribution) >= 2,
+	}, nil
+}
+
+type GetTransactionsNeedingReviewInput struct {
+	OrganizationID int
+	Month          int
+	Year           int
+}
+
+// GetTransactionsNeedingReview returns transactions that were auto-classified by
+// similarity (need confirmation) or have suggestions but no category (need action).
+func (s *service) GetTransactionsNeedingReview(ctx context.Context, input GetTransactionsNeedingReviewInput) ([]Transaction, error) {
+	models, err := s.Repository.FetchTransactionsNeedingReview(ctx, fetchTransactionsNeedingReviewParams{
+		OrganizationID: input.OrganizationID,
+		Month:          input.Month,
+		Year:           input.Year,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("fetch transactions needing review: %w", err)
+	}
+	return Transactions{}.FromModel(models), nil
 }

--- a/backend/internal/application/financial/service_test.go
+++ b/backend/internal/application/financial/service_test.go
@@ -116,6 +116,21 @@ func (m *MockRepository) FetchUncategorizedTransactions(ctx context.Context, par
 	return args.Get(0).([]TransactionModel), args.Error(1)
 }
 
+func (m *MockRepository) FetchSimilarCategoryDistribution(ctx context.Context, params fetchSimilarCategoryDistributionParams) ([]CategoryDistributionModel, error) {
+	args := m.Called(ctx, params)
+	return args.Get(0).([]CategoryDistributionModel), args.Error(1)
+}
+
+func (m *MockRepository) SetTransactionSimilarityResult(ctx context.Context, params setTransactionSimilarityResultParams) error {
+	args := m.Called(ctx, params)
+	return args.Error(0)
+}
+
+func (m *MockRepository) FetchTransactionsNeedingReview(ctx context.Context, params fetchTransactionsNeedingReviewParams) ([]TransactionModel, error) {
+	args := m.Called(ctx, params)
+	return args.Get(0).([]TransactionModel), args.Error(1)
+}
+
 // Budgets
 func (m *MockRepository) FetchBudgets(ctx context.Context, params fetchBudgetsParams) ([]BudgetModel, error) {
 	args := m.Called(ctx, params)
@@ -677,5 +692,210 @@ func TestDeletePlannedEntry_NotFound(t *testing.T) {
 
 	assert.Error(t, err)
 	assert.Equal(t, ErrPlannedEntryNotFound, err)
+	mockRepo.AssertExpectations(t)
+}
+
+// ============================================================================
+// Similarity Classification Tests
+// ============================================================================
+
+func TestSuggestCategoryForTransaction_Unambiguous_HighConfidence(t *testing.T) {
+	// When a description maps to exactly 1 category with high score,
+	// it should auto-classify.
+	mockRepo := new(MockRepository)
+	svc := &service{
+		metrics:    nil,
+		Repository: mockRepo,
+		system:     system.NewSystem(),
+	}
+
+	ctx := context.Background()
+	desc := "PAG*JoseDaSilva"
+
+	suggestedDesc := "José - Mercado"
+	mockRepo.On("FetchSimilarCategoryDistribution", ctx, mock.MatchedBy(func(p fetchSimilarCategoryDistributionParams) bool {
+		return p.OriginalDescription == desc && p.OrganizationID == 1 && p.LookbackMonths == 3
+	})).Return([]CategoryDistributionModel{
+		{CategoryID: 10, SuggestedDescription: &suggestedDesc, AvgSimilarity: 0.85, Frequency: 5, Score: 1.52},
+	}, nil)
+
+	result, err := svc.SuggestCategoryForTransaction(ctx, SuggestCategoryInput{
+		OriginalDescription: desc,
+		OrganizationID:      1,
+	})
+
+	assert.NoError(t, err)
+	assert.NotNil(t, result.CategoryID)
+	assert.Equal(t, 10, *result.CategoryID)
+	assert.NotNil(t, result.SuggestedDescription)
+	assert.Equal(t, "José - Mercado", *result.SuggestedDescription)
+	assert.False(t, result.IsAmbiguous)
+	assert.Greater(t, result.Confidence, 0.0)
+	mockRepo.AssertExpectations(t)
+}
+
+func TestSuggestCategoryForTransaction_Ambiguous_MultipleCategories(t *testing.T) {
+	// When a description maps to 2+ categories (e.g., Amazon),
+	// it should mark as ambiguous and only suggest, never auto-classify.
+	mockRepo := new(MockRepository)
+	svc := &service{
+		metrics:    nil,
+		Repository: mockRepo,
+		system:     system.NewSystem(),
+	}
+
+	ctx := context.Background()
+	desc := "AMZN MKTP US*AB1234"
+
+	mockRepo.On("FetchSimilarCategoryDistribution", ctx, mock.MatchedBy(func(p fetchSimilarCategoryDistributionParams) bool {
+		return p.OriginalDescription == desc && p.OrganizationID == 1
+	})).Return([]CategoryDistributionModel{
+		{CategoryID: 10, AvgSimilarity: 0.82, Frequency: 8, Score: 1.80},  // Electronics
+		{CategoryID: 20, AvgSimilarity: 0.80, Frequency: 4, Score: 1.28},  // Groceries
+		{CategoryID: 30, AvgSimilarity: 0.78, Frequency: 2, Score: 0.86},  // Household
+	}, nil)
+
+	result, err := svc.SuggestCategoryForTransaction(ctx, SuggestCategoryInput{
+		OriginalDescription: desc,
+		OrganizationID:      1,
+	})
+
+	assert.NoError(t, err)
+	assert.True(t, result.IsAmbiguous)
+	// Should still return the best suggestion even when ambiguous
+	assert.NotNil(t, result.CategoryID)
+	assert.Equal(t, 10, *result.CategoryID) // Highest score
+	mockRepo.AssertExpectations(t)
+}
+
+func TestSuggestCategoryForTransaction_NoHistory(t *testing.T) {
+	// When there are no similar transactions at all,
+	// it should return nil category (unknown).
+	mockRepo := new(MockRepository)
+	svc := &service{
+		metrics:    nil,
+		Repository: mockRepo,
+		system:     system.NewSystem(),
+	}
+
+	ctx := context.Background()
+	desc := "COMPLETELY NEW MERCHANT"
+
+	mockRepo.On("FetchSimilarCategoryDistribution", ctx, mock.MatchedBy(func(p fetchSimilarCategoryDistributionParams) bool {
+		return p.OriginalDescription == desc
+	})).Return([]CategoryDistributionModel{}, nil)
+
+	result, err := svc.SuggestCategoryForTransaction(ctx, SuggestCategoryInput{
+		OriginalDescription: desc,
+		OrganizationID:      1,
+	})
+
+	assert.NoError(t, err)
+	assert.Nil(t, result.CategoryID)
+	assert.False(t, result.IsAmbiguous)
+	assert.Equal(t, 0.0, result.Confidence)
+	mockRepo.AssertExpectations(t)
+}
+
+func TestSuggestCategoryForTransaction_Unambiguous_LowConfidence(t *testing.T) {
+	// When a description maps to 1 category but with a low score,
+	// it should still suggest (not auto-classify). The caller decides the threshold.
+	mockRepo := new(MockRepository)
+	svc := &service{
+		metrics:    nil,
+		Repository: mockRepo,
+		system:     system.NewSystem(),
+	}
+
+	ctx := context.Background()
+	desc := "PARTIAL MATCH DESC"
+
+	mockRepo.On("FetchSimilarCategoryDistribution", ctx, mock.MatchedBy(func(p fetchSimilarCategoryDistributionParams) bool {
+		return p.OriginalDescription == desc
+	})).Return([]CategoryDistributionModel{
+		{CategoryID: 15, AvgSimilarity: 0.45, Frequency: 1, Score: 0.31},
+	}, nil)
+
+	result, err := svc.SuggestCategoryForTransaction(ctx, SuggestCategoryInput{
+		OriginalDescription: desc,
+		OrganizationID:      1,
+	})
+
+	assert.NoError(t, err)
+	assert.NotNil(t, result.CategoryID)
+	assert.Equal(t, 15, *result.CategoryID)
+	assert.False(t, result.IsAmbiguous)
+	// Low confidence — caller should decide to suggest rather than auto-classify
+	assert.Less(t, result.Confidence, 1.0)
+	mockRepo.AssertExpectations(t)
+}
+
+func TestSuggestCategoryForTransaction_RepositoryError(t *testing.T) {
+	mockRepo := new(MockRepository)
+	svc := &service{
+		metrics:    nil,
+		Repository: mockRepo,
+		system:     system.NewSystem(),
+	}
+
+	ctx := context.Background()
+
+	mockRepo.On("FetchSimilarCategoryDistribution", ctx, mock.Anything).
+		Return([]CategoryDistributionModel{}, fmt.Errorf("database error"))
+
+	_, err := svc.SuggestCategoryForTransaction(ctx, SuggestCategoryInput{
+		OriginalDescription: "anything",
+		OrganizationID:      1,
+	})
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "fetch similar categories")
+	mockRepo.AssertExpectations(t)
+}
+
+func TestGetTransactionsNeedingReview_Success(t *testing.T) {
+	mockRepo := new(MockRepository)
+	svc := &service{
+		metrics:    nil,
+		Repository: mockRepo,
+		system:     system.NewSystem(),
+	}
+
+	ctx := context.Background()
+	classifiedBy := "similarity"
+	suggestedCatID := 10
+	confidence := 0.75
+
+	expectedModels := []TransactionModel{
+		{
+			TransactionID: 1,
+			Description:   "Auto-classified",
+			ClassifiedBy:  &classifiedBy,
+			CategoryID:    &suggestedCatID,
+		},
+		{
+			TransactionID:        2,
+			Description:          "Suggestion only",
+			SuggestedCategoryID:  &suggestedCatID,
+			SuggestionConfidence: &confidence,
+		},
+	}
+
+	mockRepo.On("FetchTransactionsNeedingReview", ctx, fetchTransactionsNeedingReviewParams{
+		OrganizationID: 1,
+		Month:          3,
+		Year:           2026,
+	}).Return(expectedModels, nil)
+
+	result, err := svc.GetTransactionsNeedingReview(ctx, GetTransactionsNeedingReviewInput{
+		OrganizationID: 1,
+		Month:          3,
+		Year:           2026,
+	})
+
+	assert.NoError(t, err)
+	assert.Len(t, result, 2)
+	assert.Equal(t, "Auto-classified", result[0].Description)
+	assert.Equal(t, "Suggestion only", result[1].Description)
 	mockRepo.AssertExpectations(t)
 }

--- a/backend/internal/application/financial/service_test.go
+++ b/backend/internal/application/financial/service_test.go
@@ -2,6 +2,7 @@ package financial
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 	"testing"
 
@@ -649,5 +650,32 @@ func TestDeletePlannedEntry_RepositoryError(t *testing.T) {
 
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to delete planned entry")
+	mockRepo.AssertExpectations(t)
+}
+
+func TestDeletePlannedEntry_NotFound(t *testing.T) {
+	mockRepo := new(MockRepository)
+	svc := &service{
+		metrics:    nil,
+		Repository: mockRepo,
+		system:     system.NewSystem(),
+	}
+
+	ctx := context.Background()
+
+	mockRepo.On("RemovePlannedEntry", ctx, removePlannedEntryParams{
+		PlannedEntryID: 999,
+		UserID:         1,
+		OrganizationID: 1,
+	}).Return(sql.ErrNoRows)
+
+	err := svc.DeletePlannedEntry(ctx, DeletePlannedEntryInput{
+		PlannedEntryID: 999,
+		UserID:         1,
+		OrganizationID: 1,
+	})
+
+	assert.Error(t, err)
+	assert.Equal(t, ErrPlannedEntryNotFound, err)
 	mockRepo.AssertExpectations(t)
 }

--- a/backend/internal/application/financial/service_test.go
+++ b/backend/internal/application/financial/service_test.go
@@ -2,6 +2,7 @@ package financial
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/catrutech/celeiro/pkg/system"
@@ -595,5 +596,58 @@ func TestGetTransactions_DefaultLimit(t *testing.T) {
 	})
 
 	assert.NoError(t, err)
+	mockRepo.AssertExpectations(t)
+}
+
+func TestDeletePlannedEntry_Success(t *testing.T) {
+	mockRepo := new(MockRepository)
+	svc := &service{
+		metrics:    nil,
+		Repository: mockRepo,
+		system:     system.NewSystem(),
+	}
+
+	ctx := context.Background()
+
+	mockRepo.On("RemovePlannedEntry", ctx, removePlannedEntryParams{
+		PlannedEntryID: 42,
+		UserID:         1,
+		OrganizationID: 1,
+	}).Return(nil)
+
+	err := svc.DeletePlannedEntry(ctx, DeletePlannedEntryInput{
+		PlannedEntryID: 42,
+		UserID:         1,
+		OrganizationID: 1,
+	})
+
+	assert.NoError(t, err)
+	mockRepo.AssertExpectations(t)
+}
+
+func TestDeletePlannedEntry_RepositoryError(t *testing.T) {
+	mockRepo := new(MockRepository)
+	svc := &service{
+		metrics:    nil,
+		Repository: mockRepo,
+		system:     system.NewSystem(),
+	}
+
+	ctx := context.Background()
+
+	mockRepo.On("RemovePlannedEntry", ctx, removePlannedEntryParams{
+		PlannedEntryID: 99,
+		UserID:         1,
+		OrganizationID: 1,
+	}).Return(fmt.Errorf("entry not found"))
+
+	err := svc.DeletePlannedEntry(ctx, DeletePlannedEntryInput{
+		PlannedEntryID: 99,
+		UserID:         1,
+		OrganizationID: 1,
+	})
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to delete planned entry")
 	mockRepo.AssertExpectations(t)
 }

--- a/backend/internal/errors/errors.go
+++ b/backend/internal/errors/errors.go
@@ -28,6 +28,9 @@ var (
 	// Transaction pattern draft errors
 	ErrTransactionCategoryRequired    = pkgerrors.New("transaction has no category")
 	ErrTransactionDescriptionRequired = pkgerrors.New("transaction has no usable description")
+
+	// Planned entry errors
+	ErrPlannedEntryNotFound = pkgerrors.New("planned entry not found")
 )
 
 func NewInvalidTimeFormatError(field string) error {

--- a/backend/internal/migrations/00042_similarity_classification.sql
+++ b/backend/internal/migrations/00042_similarity_classification.sql
@@ -1,0 +1,37 @@
+-- +goose Up
+-- Migration: Add similarity-based auto-categorization support
+--
+-- Enables pg_trgm for fuzzy matching on original_description,
+-- adds fields to track how a transaction was classified and
+-- store category suggestions with confidence scores.
+
+-- Step 1: Enable trigram similarity extension
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+
+-- Step 2: Add classification tracking field
+-- Values: 'manual', 'pattern', 'planned_entry', 'similarity'
+-- NULL for legacy transactions (treated as 'manual')
+ALTER TABLE transactions ADD COLUMN classified_by TEXT;
+
+-- Step 3: Add suggestion fields for ambiguous/low-confidence matches
+ALTER TABLE transactions ADD COLUMN suggested_category_id INT
+    REFERENCES categories(category_id) ON DELETE SET NULL;
+ALTER TABLE transactions ADD COLUMN suggested_description TEXT;
+ALTER TABLE transactions ADD COLUMN suggestion_confidence DECIMAL(4,3)
+    CHECK (suggestion_confidence IS NULL OR (suggestion_confidence >= 0 AND suggestion_confidence <= 1));
+
+-- Step 4: GIN index for fast trigram similarity lookups
+CREATE INDEX idx_transactions_original_desc_trgm
+    ON transactions USING gin (original_description gin_trgm_ops);
+
+-- Step 5: Backfill classified_by for pattern-matched transactions
+UPDATE transactions SET classified_by = 'pattern'
+    WHERE classification_rule_id IS NOT NULL AND classified_by IS NULL;
+
+-- +goose Down
+DROP INDEX IF EXISTS idx_transactions_original_desc_trgm;
+ALTER TABLE transactions DROP COLUMN IF EXISTS suggestion_confidence;
+ALTER TABLE transactions DROP COLUMN IF EXISTS suggested_description;
+ALTER TABLE transactions DROP COLUMN IF EXISTS suggested_category_id;
+ALTER TABLE transactions DROP COLUMN IF EXISTS classified_by;
+-- Note: We don't drop pg_trgm as other things may depend on it

--- a/backend/internal/web/financial/handler.go
+++ b/backend/internal/web/financial/handler.go
@@ -1487,6 +1487,10 @@ func (h *Handler) DeletePlannedEntry(w http.ResponseWriter, r *http.Request) {
 		OrganizationID: organizationID,
 	})
 	if err != nil {
+		if err == financialApp.ErrPlannedEntryNotFound {
+			responses.NewError(w, errors.ErrPlannedEntryNotFound)
+			return
+		}
 		responses.NewError(w, err)
 		return
 	}

--- a/backend/internal/web/financial/handler.go
+++ b/backend/internal/web/financial/handler.go
@@ -446,6 +446,34 @@ func (h *Handler) ListUncategorizedTransactions(w http.ResponseWriter, r *http.R
 	responses.NewSuccess(transactions, w)
 }
 
+func (h *Handler) ListTransactionsNeedingReview(w http.ResponseWriter, r *http.Request) {
+	_, organizationID, err := h.getSessionInfo(r)
+	if err != nil {
+		responses.NewError(w, errors.ErrUnauthorized)
+		return
+	}
+
+	month, _ := strconv.Atoi(r.URL.Query().Get("month"))
+	year, _ := strconv.Atoi(r.URL.Query().Get("year"))
+
+	if month == 0 || year == 0 {
+		responses.NewError(w, errors.ErrInvalidRequestBody)
+		return
+	}
+
+	transactions, err := h.app.FinancialService.GetTransactionsNeedingReview(r.Context(), financialApp.GetTransactionsNeedingReviewInput{
+		OrganizationID: organizationID,
+		Month:          month,
+		Year:           year,
+	})
+	if err != nil {
+		responses.NewError(w, err)
+		return
+	}
+
+	responses.NewSuccess(transactions, w)
+}
+
 func (h *Handler) ImportOFX(w http.ResponseWriter, r *http.Request) {
 	userID, organizationID, err := h.getSessionInfo(r)
 	if err != nil {

--- a/backend/internal/web/responses/responses.go
+++ b/backend/internal/web/responses/responses.go
@@ -39,6 +39,7 @@ var errorMappings = map[error]ErrorMapping{
 	errors.ErrInvalidCode:                    {Status: http.StatusUnauthorized, Code: "INVALID_CODE"},
 	errors.ErrTransactionCategoryRequired:    {Status: http.StatusBadRequest, Code: "TRANSACTION_CATEGORY_REQUIRED"},
 	errors.ErrTransactionDescriptionRequired: {Status: http.StatusBadRequest, Code: "TRANSACTION_DESCRIPTION_REQUIRED"},
+	errors.ErrPlannedEntryNotFound:           {Status: http.StatusNotFound, Code: "PLANNED_ENTRY_NOT_FOUND"},
 }
 
 func NewSuccess[T any](data T, w http.ResponseWriter, status ...int) {

--- a/backend/internal/web/router.go
+++ b/backend/internal/web/router.go
@@ -96,6 +96,7 @@ func NewRouter(application *application.Application, logger logging.Logger, cfg 
 		// Transactions
 		r.Get("/accounts/{accountId}/transactions", mw.RequireSession(fh.ListTransactions, []accounts.Permission{}))
 		r.Get("/transactions/uncategorized", mw.RequireSession(fh.ListUncategorizedTransactions, []accounts.Permission{}))
+		r.Get("/transactions/needs-review", mw.RequireSession(fh.ListTransactionsNeedingReview, []accounts.Permission{}))
 		r.Post("/accounts/{accountId}/transactions", mw.RequireSession(fh.CreateTransaction, []accounts.Permission{}))
 		r.Post("/accounts/{accountId}/transactions/import", mw.RequireSession(fh.ImportOFX, []accounts.Permission{}))
 		r.Patch("/accounts/{accountId}/transactions/{transactionId}", mw.RequireSession(fh.UpdateTransaction, []accounts.Permission{}))

--- a/frontend/src/components/CategoryBudgetCard.tsx
+++ b/frontend/src/components/CategoryBudgetCard.tsx
@@ -599,7 +599,7 @@ export default function CategoryBudgetCard({
                           Desvincular
                         </button>
                       )}
-                      {(entry.Status === 'pending' || entry.Status === 'missed') && onDismissEntry && (
+                      {(entry.Status === 'scheduled' || entry.Status === 'pending' || entry.Status === 'missed') && onDismissEntry && (
                         <button
                           onClick={() => {
                             setDismissingEntryId(entry.PlannedEntryID);

--- a/frontend/src/components/CategoryBudgetCard.tsx
+++ b/frontend/src/components/CategoryBudgetCard.tsx
@@ -646,13 +646,13 @@ export default function CategoryBudgetCard({
                           Criar padrão do vínculo
                         </button>
                       )}
-                      {onDeleteEntry && (
+                      {onDeleteEntry && entry.Status !== 'matched' && (
                         <button
                           onClick={() => {
                             if (confirm(`Excluir "${entry.Description}"?`)) {
                               onDeleteEntry(entry.PlannedEntryID);
+                              setExpandedEntryActions(null);
                             }
-                            setExpandedEntryActions(null);
                           }}
                           className="w-full text-left px-3 py-1.5 text-sm hover:bg-rust-50 text-rust-600"
                         >

--- a/frontend/src/components/CategoryBudgetDashboard.tsx
+++ b/frontend/src/components/CategoryBudgetDashboard.tsx
@@ -1741,6 +1741,9 @@ export default function CategoryBudgetDashboard() {
               onPlannedEntryClick={handlePlannedEntryClickInBudget}
               onAddPlannedEntry={handleAddPlannedEntryFromModal}
               onUpdatePlannedEntryAmount={handleUpdatePlannedEntryAmountInline}
+              onDismissEntry={(entryId, reason) => handleDismissExpandedEntry(entryId, selectedMonth, selectedYear, reason)}
+              onUndismissEntry={(entryId) => handleUndismissExpandedEntry(entryId, selectedMonth, selectedYear)}
+              onDeleteEntry={(entryId) => handleDeletePlannedEntry(entryId, selectedMonth, selectedYear)}
             />
           );
         })()}

--- a/frontend/src/components/CategoryTransactionsModal.tsx
+++ b/frontend/src/components/CategoryTransactionsModal.tsx
@@ -3,6 +3,7 @@ import type { Transaction } from '../types/transaction';
 import type { PlannedEntryWithStatus } from '../types/budget';
 import type { Category } from '../types/category';
 import { useModalDismiss } from '../hooks/useModalDismiss';
+import { useDropdownClose } from '../hooks/useDropdownClose';
 import { parseTransactionDate } from '../utils/date';
 
 interface CategoryTransactionsModalProps {
@@ -21,6 +22,9 @@ interface CategoryTransactionsModalProps {
   onPlannedEntryClick?: (entry: PlannedEntryWithStatus) => void;
   onAddPlannedEntry?: () => void;
   onUpdatePlannedEntryAmount?: (entryId: number, newAmount: number) => Promise<void>;
+  onDismissEntry?: (entryId: number, reason?: string) => void;
+  onUndismissEntry?: (entryId: number) => void;
+  onDeleteEntry?: (entryId: number) => void;
 }
 
 export default function CategoryTransactionsModal({
@@ -39,12 +43,19 @@ export default function CategoryTransactionsModal({
   onPlannedEntryClick,
   onAddPlannedEntry,
   onUpdatePlannedEntryAmount,
+  onDismissEntry,
+  onUndismissEntry,
+  onDeleteEntry,
 }: CategoryTransactionsModalProps) {
   const { handleBackdropClick, handleBackdropMouseDown } = useModalDismiss(onClose);
 
   // Inline editing state
   const [editingEntryId, setEditingEntryId] = useState<number | null>(null);
   const [editingAmount, setEditingAmount] = useState<string>('');
+
+  // Dropdown menu state for planned entry actions
+  const [openEntryMenuId, setOpenEntryMenuId] = useState<number | null>(null);
+  const entryMenuRef = useDropdownClose(openEntryMenuId !== null, () => setOpenEntryMenuId(null));
 
   const formatCurrency = (amount: string | number) => {
     const num = typeof amount === 'number' ? amount : parseFloat(amount);
@@ -337,17 +348,88 @@ export default function CategoryTransactionsModal({
                             </span>
                           )}
 
-                          {/* Edit button for full entry */}
-                          {onPlannedEntryClick && !isEditing && (
-                            <button
-                              onClick={() => onPlannedEntryClick(entry)}
-                              className="p-1 text-stone-400 hover:text-stone-600"
-                              title="Editar entrada"
-                            >
-                              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z" />
-                              </svg>
-                            </button>
+                          {/* 3-dot actions menu */}
+                          {!isEditing && (
+                            <div className="relative">
+                              <button
+                                data-entry-menu={entry.PlannedEntryID}
+                                onClick={() => setOpenEntryMenuId(openEntryMenuId === entry.PlannedEntryID ? null : entry.PlannedEntryID)}
+                                className="p-1 hover:bg-stone-100 rounded-full transition-colors"
+                                aria-label="Ações"
+                              >
+                                <svg className="w-5 h-5 text-stone-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 5v.01M12 12v.01M12 19v.01M12 6a1 1 0 110-2 1 1 0 010 2zm0 7a1 1 0 110-2 1 1 0 010 2zm0 7a1 1 0 110-2 1 1 0 010 2z" />
+                                </svg>
+                              </button>
+
+                              {openEntryMenuId === entry.PlannedEntryID && (
+                                <div
+                                  ref={entryMenuRef}
+                                  className="fixed z-[60] w-48 bg-stone-50 rounded-lg shadow-lg border border-stone-200 py-1"
+                                  style={{
+                                    top: (() => {
+                                      const btn = document.querySelector(`[data-entry-menu="${entry.PlannedEntryID}"]`);
+                                      if (!btn) return 0;
+                                      const rect = btn.getBoundingClientRect();
+                                      return rect.bottom + 4;
+                                    })(),
+                                    right: (() => {
+                                      const btn = document.querySelector(`[data-entry-menu="${entry.PlannedEntryID}"]`);
+                                      if (!btn) return 0;
+                                      const rect = btn.getBoundingClientRect();
+                                      return window.innerWidth - rect.right;
+                                    })(),
+                                  }}
+                                >
+                                  {(entry.Status === 'scheduled' || entry.Status === 'pending' || entry.Status === 'missed') && onDismissEntry && (
+                                    <button
+                                      onClick={() => {
+                                        onDismissEntry(entry.PlannedEntryID);
+                                        setOpenEntryMenuId(null);
+                                      }}
+                                      className="w-full text-left px-4 py-2 hover:bg-stone-100 text-stone-700 text-sm"
+                                    >
+                                      Dispensar
+                                    </button>
+                                  )}
+                                  {entry.Status === 'dismissed' && onUndismissEntry && (
+                                    <button
+                                      onClick={() => {
+                                        onUndismissEntry(entry.PlannedEntryID);
+                                        setOpenEntryMenuId(null);
+                                      }}
+                                      className="w-full text-left px-4 py-2 hover:bg-stone-100 text-stone-700 text-sm"
+                                    >
+                                      Reativar
+                                    </button>
+                                  )}
+                                  {onPlannedEntryClick && (
+                                    <button
+                                      onClick={() => {
+                                        onPlannedEntryClick(entry);
+                                        setOpenEntryMenuId(null);
+                                      }}
+                                      className="w-full text-left px-4 py-2 hover:bg-stone-100 text-stone-700 text-sm"
+                                    >
+                                      Editar
+                                    </button>
+                                  )}
+                                  {onDeleteEntry && (
+                                    <button
+                                      onClick={() => {
+                                        if (confirm(`Tem certeza que deseja excluir "${entry.Description}"? Esta ação não pode ser desfeita.`)) {
+                                          onDeleteEntry(entry.PlannedEntryID);
+                                        }
+                                        setOpenEntryMenuId(null);
+                                      }}
+                                      className="w-full text-left px-4 py-2 hover:bg-rust-50 text-rust-600 text-sm"
+                                    >
+                                      Excluir
+                                    </button>
+                                  )}
+                                </div>
+                              )}
+                            </div>
                           )}
                         </div>
                       </div>

--- a/frontend/src/components/CategoryTransactionsModal.tsx
+++ b/frontend/src/components/CategoryTransactionsModal.tsx
@@ -414,13 +414,13 @@ export default function CategoryTransactionsModal({
                                       Editar
                                     </button>
                                   )}
-                                  {onDeleteEntry && (
+                                  {onDeleteEntry && entry.Status !== 'matched' && (
                                     <button
                                       onClick={() => {
                                         if (confirm(`Tem certeza que deseja excluir "${entry.Description}"? Esta ação não pode ser desfeita.`)) {
                                           onDeleteEntry(entry.PlannedEntryID);
+                                          setOpenEntryMenuId(null);
                                         }
-                                        setOpenEntryMenuId(null);
                                       }}
                                       className="w-full text-left px-4 py-2 hover:bg-rust-50 text-rust-600 text-sm"
                                     >

--- a/frontend/src/components/TransactionList.tsx
+++ b/frontend/src/components/TransactionList.tsx
@@ -273,6 +273,8 @@ export default function TransactionList() {
 
     let totalImported = 0;
     let totalDuplicates = 0;
+    let totalSimilarityMatched = 0;
+    let totalSuggested = 0;
     let failedFiles: string[] = [];
 
     for (const file of ofxFiles) {
@@ -310,9 +312,19 @@ export default function TransactionList() {
           result?.data?.duplicate_count ??
           result?.data?.duplicateCount ??
           0;
+        const similarityMatched =
+          result?.data?.SimilarityMatchedCount ??
+          result?.data?.similarity_matched_count ??
+          0;
+        const suggested =
+          result?.data?.SuggestedCount ??
+          result?.data?.suggested_count ??
+          0;
 
         totalImported += typeof imported === 'number' ? imported : 0;
         totalDuplicates += typeof duplicates === 'number' ? duplicates : 0;
+        totalSimilarityMatched += typeof similarityMatched === 'number' ? similarityMatched : 0;
+        totalSuggested += typeof suggested === 'number' ? suggested : 0;
       } catch (err) {
         failedFiles.push(`${file.name}: ${err instanceof Error ? err.message : 'Erro desconhecido'}`);
       }
@@ -325,8 +337,10 @@ export default function TransactionList() {
 
     if (totalImported > 0 || totalDuplicates > 0) {
       const filesText = ofxFiles.length > 1 ? `${ofxFiles.length} arquivos` : '1 arquivo';
-      setUploadSuccess(`✅ ${filesText}: ${totalImported} transações importadas (${totalDuplicates} duplicadas).`);
-      setTimeout(() => setUploadSuccess(null), 5000);
+      const autoClassifiedText = totalSimilarityMatched > 0 ? `, ${totalSimilarityMatched} já categorizadas` : '';
+      const suggestedText = totalSuggested > 0 ? `, ${totalSuggested} com sugestão para revisar` : '';
+      setUploadSuccess(`${filesText}: ${totalImported} transações importadas (${totalDuplicates} duplicadas${autoClassifiedText}${suggestedText}).`);
+      setTimeout(() => setUploadSuccess(null), 7000);
     }
 
     // Refresh the transaction list
@@ -457,6 +471,14 @@ export default function TransactionList() {
 
   const handleInlineCategorySave = useCallback(async (transaction: Transaction, categoryId: number | null) => {
     await handleInlineSave(transaction, { category_id: categoryId });
+  }, [handleInlineSave]);
+
+  const handleAcceptSuggestion = useCallback(async (transaction: Transaction) => {
+    const patch: Record<string, unknown> = { category_id: transaction.suggested_category_id };
+    if (transaction.suggested_description) {
+      patch.description = transaction.suggested_description;
+    }
+    await handleInlineSave(transaction, patch);
   }, [handleInlineSave]);
 
   const handleCreateTransaction = async () => {
@@ -969,6 +991,25 @@ export default function TransactionList() {
                       transactionType={transaction.transaction_type}
                       onSave={(catId) => handleInlineCategorySave(transaction, catId)}
                     />
+                    {transaction.classified_by === 'similarity' && transaction.category_id && (
+                      <button
+                        className="text-xs bg-wheat-50 text-wheat-700 px-2 py-0.5 rounded-full font-medium hover:bg-wheat-100 transition-colors cursor-pointer"
+                        title="Confirmar categoria"
+                        onClick={() => handleInlineCategorySave(transaction, transaction.category_id!)}
+                      >
+                        ✓ Auto
+                      </button>
+                    )}
+                    {!transaction.category_id && transaction.suggested_category_id && (
+                      <button
+                        className="text-xs bg-terra-50 text-terra-700 px-2 py-0.5 rounded-full font-medium hover:bg-terra-100 transition-colors"
+                        title={`Usar: ${transaction.suggested_description ?? ''} → ${categories.get(transaction.suggested_category_id)?.name ?? 'categoria'}`}
+                        onClick={() => handleAcceptSuggestion(transaction)}
+                      >
+                        {categories.get(transaction.suggested_category_id)?.icon}{' '}
+                        {transaction.suggested_description ?? 'Sugestão'}
+                      </button>
+                    )}
                     {transaction.is_ignored && (
                       <span className="text-xs bg-stone-200 text-stone-600 px-1.5 py-0.5 rounded font-medium">
                         IGNORADA
@@ -1063,12 +1104,33 @@ export default function TransactionList() {
                         {formatCurrency(transaction.amount)}
                       </td>
                       <td className="px-6 py-4 whitespace-nowrap text-sm text-stone-500">
-                        <InlineCategoryPicker
-                          categoryId={transaction.category_id}
-                          categories={categories}
-                          transactionType={transaction.transaction_type}
-                          onSave={(catId) => handleInlineCategorySave(transaction, catId)}
-                        />
+                        <div className="flex items-center gap-1.5">
+                          <InlineCategoryPicker
+                            categoryId={transaction.category_id}
+                            categories={categories}
+                            transactionType={transaction.transaction_type}
+                            onSave={(catId) => handleInlineCategorySave(transaction, catId)}
+                          />
+                          {transaction.classified_by === 'similarity' && transaction.category_id && (
+                            <button
+                              className="text-xs bg-wheat-50 text-wheat-700 px-2 py-0.5 rounded-full font-medium hover:bg-wheat-100 transition-colors cursor-pointer"
+                              title="Confirmar categoria"
+                              onClick={() => handleInlineCategorySave(transaction, transaction.category_id!)}
+                            >
+                              ✓ Auto
+                            </button>
+                          )}
+                          {!transaction.category_id && transaction.suggested_category_id && (
+                            <button
+                              className="text-xs bg-terra-50 text-terra-700 px-2 py-0.5 rounded-full font-medium hover:bg-terra-100 transition-colors"
+                              title={`Usar: ${transaction.suggested_description ?? ''} → ${categories.get(transaction.suggested_category_id)?.name ?? 'categoria'}`}
+                              onClick={() => handleAcceptSuggestion(transaction)}
+                            >
+                              {categories.get(transaction.suggested_category_id)?.icon}{' '}
+                              {transaction.suggested_description ?? 'Sugestão'}
+                            </button>
+                          )}
+                        </div>
                       </td>
                       <td className="w-12 px-2 py-4">
                         <ActionMenu

--- a/frontend/src/components/TransactionList.tsx
+++ b/frontend/src/components/TransactionList.tsx
@@ -474,10 +474,29 @@ export default function TransactionList() {
   }, [handleInlineSave]);
 
   const handleAcceptSuggestion = useCallback(async (transaction: Transaction) => {
-    const patch: Record<string, unknown> = { category_id: transaction.suggested_category_id };
+    const patch: Record<string, unknown> = {
+      category_id: transaction.suggested_category_id,
+      // Clear suggestion fields optimistically so badges disappear immediately
+      suggested_category_id: null,
+      suggested_description: null,
+      suggestion_confidence: null,
+      classified_by: 'manual',
+    };
     if (transaction.suggested_description) {
       patch.description = transaction.suggested_description;
     }
+    await handleInlineSave(transaction, patch);
+  }, [handleInlineSave]);
+
+  const handleConfirmAutoClassification = useCallback(async (transaction: Transaction) => {
+    // Optimistically clear the similarity badge before the API call
+    const patch: Record<string, unknown> = {
+      category_id: transaction.category_id,
+      classified_by: 'manual',
+      suggested_category_id: null,
+      suggested_description: null,
+      suggestion_confidence: null,
+    };
     await handleInlineSave(transaction, patch);
   }, [handleInlineSave]);
 
@@ -993,20 +1012,20 @@ export default function TransactionList() {
                     />
                     {transaction.classified_by === 'similarity' && transaction.category_id && (
                       <button
-                        className="text-xs bg-wheat-50 text-wheat-700 px-2 py-0.5 rounded-full font-medium hover:bg-wheat-100 transition-colors cursor-pointer"
+                        className="text-xs bg-wheat-50 text-wheat-700 px-2 py-0.5 rounded-full font-medium hover:bg-wheat-100 transition-colors cursor-pointer focus:outline-none focus:ring-2 focus:ring-wheat-300"
                         title="Confirmar categoria"
-                        onClick={() => handleInlineCategorySave(transaction, transaction.category_id!)}
+                        onClick={() => handleConfirmAutoClassification(transaction)}
                       >
                         ✓ Auto
                       </button>
                     )}
-                    {!transaction.category_id && transaction.suggested_category_id && (
+                    {!transaction.category_id && transaction.suggested_category_id && categories.get(transaction.suggested_category_id) && (
                       <button
-                        className="text-xs bg-terra-50 text-terra-700 px-2 py-0.5 rounded-full font-medium hover:bg-terra-100 transition-colors"
-                        title={`Usar: ${transaction.suggested_description ?? ''} → ${categories.get(transaction.suggested_category_id)?.name ?? 'categoria'}`}
+                        className="text-xs bg-terra-50 text-terra-700 px-2 py-0.5 rounded-full font-medium hover:bg-terra-100 transition-colors max-w-[200px] truncate focus:outline-none focus:ring-2 focus:ring-terra-300"
+                        title={`Usar: ${transaction.suggested_description ?? categories.get(transaction.suggested_category_id)!.name} → ${categories.get(transaction.suggested_category_id)!.name}`}
                         onClick={() => handleAcceptSuggestion(transaction)}
                       >
-                        {categories.get(transaction.suggested_category_id)?.icon}{' '}
+                        {categories.get(transaction.suggested_category_id)!.icon}{' '}
                         {transaction.suggested_description ?? 'Sugestão'}
                       </button>
                     )}
@@ -1113,20 +1132,20 @@ export default function TransactionList() {
                           />
                           {transaction.classified_by === 'similarity' && transaction.category_id && (
                             <button
-                              className="text-xs bg-wheat-50 text-wheat-700 px-2 py-0.5 rounded-full font-medium hover:bg-wheat-100 transition-colors cursor-pointer"
+                              className="text-xs bg-wheat-50 text-wheat-700 px-2 py-0.5 rounded-full font-medium hover:bg-wheat-100 transition-colors cursor-pointer focus:outline-none focus:ring-2 focus:ring-wheat-300"
                               title="Confirmar categoria"
-                              onClick={() => handleInlineCategorySave(transaction, transaction.category_id!)}
+                              onClick={() => handleConfirmAutoClassification(transaction)}
                             >
                               ✓ Auto
                             </button>
                           )}
-                          {!transaction.category_id && transaction.suggested_category_id && (
+                          {!transaction.category_id && transaction.suggested_category_id && categories.get(transaction.suggested_category_id) && (
                             <button
-                              className="text-xs bg-terra-50 text-terra-700 px-2 py-0.5 rounded-full font-medium hover:bg-terra-100 transition-colors"
-                              title={`Usar: ${transaction.suggested_description ?? ''} → ${categories.get(transaction.suggested_category_id)?.name ?? 'categoria'}`}
+                              className="text-xs bg-terra-50 text-terra-700 px-2 py-0.5 rounded-full font-medium hover:bg-terra-100 transition-colors max-w-[180px] truncate focus:outline-none focus:ring-2 focus:ring-terra-300"
+                              title={`Usar: ${transaction.suggested_description ?? categories.get(transaction.suggested_category_id)!.name} → ${categories.get(transaction.suggested_category_id)!.name}`}
                               onClick={() => handleAcceptSuggestion(transaction)}
                             >
-                              {categories.get(transaction.suggested_category_id)?.icon}{' '}
+                              {categories.get(transaction.suggested_category_id)!.icon}{' '}
                               {transaction.suggested_description ?? 'Sugestão'}
                             </button>
                           )}

--- a/frontend/src/types/transaction.ts
+++ b/frontend/src/types/transaction.ts
@@ -14,6 +14,10 @@ export interface Transaction {
   is_classified: boolean;
   classification_rule_id: number | null;
   is_ignored: boolean;
+  classified_by: 'manual' | 'pattern' | 'planned_entry' | 'similarity' | null;
+  suggested_category_id: number | null;
+  suggested_description: string | null;
+  suggestion_confidence: number | null;
   notes: string | null;
   tags: string[] | null;
   created_at: string;


### PR DESCRIPTION
## Summary
- Auto-categorizes transactions on OFX import using pg_trgm similarity matching against 3-month categorization history
- Suggests both category and description based on most frequent past matches (MODE() aggregate)
- Three-outcome model: auto-classify (unambiguous + high confidence), suggest-only (ambiguous, e.g. Amazon), or skip (no history)
- Wheat "✓ Auto" badge for auto-classified transactions (one-click confirm)
- Terra suggestion badge showing suggested description + category icon (one-click accept)
- Hardened against edge cases: long text truncation, deleted categories, keyboard focus, optimistic updates

## Test plan
- [x] 6 service tests: unambiguous, ambiguous, no history, low confidence, repository error, needs-review
- [x] Full test suite passes (60 tests)
- [x] TypeScript compiles cleanly
- [x] Visual verification with Playwright (desktop + mobile screenshots)
- [ ] Deploy and test with real OFX import on staging

🤖 Generated with [Claude Code](https://claude.com/claude-code)