### PR TITLE
refactor: optimize pacing to fetch only needed categories

### DIFF
--- a/backend/internal/application/financial/budget_progress.go
+++ b/backend/internal/application/financial/budget_progress.go
@@ -374,7 +374,7 @@ type GetControllableCategoryPacingInput struct {
 	Year           int
 }
 
-// GetControllableCategoryPacing calculates pacing data for all controllable categories
+// GetControllableCategoryPacing calculates pacing data for all categories with a non-zero controlled_amount budget
 func (s *service) GetControllableCategoryPacing(ctx context.Context, input GetControllableCategoryPacingInput) (*ControllableCategoryPacing, error) {
 	// Calculate time-based values
 	now := s.system.Time.Now()
@@ -382,16 +382,8 @@ func (s *service) GetControllableCategoryPacing(ctx context.Context, input GetCo
 	daysInMonth := time.Date(input.Year, time.Month(input.Month+1), 0, 0, 0, 0, 0, time.UTC).Day()
 	progressPercentage := float64(currentDay) / float64(daysInMonth) * 100
 
-	// Fetch all categories for the organization
-	categories, err := s.Repository.FetchCategories(ctx, fetchCategoriesParams{
-		OrganizationID: &input.OrganizationID,
-		IncludeSystem:  false,
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	// Fetch category budgets for the month
+	// Fetch category budgets for the month — controllable categories are determined
+	// by having a non-zero controlled_amount, not by the is_controllable flag
 	categoryBudgets, err := s.Repository.FetchCategoryBudgets(ctx, fetchCategoryBudgetsParams{
 		UserID:         input.UserID,
 		OrganizationID: input.OrganizationID,
@@ -402,29 +394,22 @@ func (s *service) GetControllableCategoryPacing(ctx context.Context, input GetCo
 		return nil, err
 	}
 
-	// Create map of category ID -> controlled amount
-	// Include all categories that have a non-zero controlled amount
-	budgetMap := make(map[int]decimal.Decimal)
+	// Filter to only budgets with non-zero controlled amount
+	type controllableBudget struct {
+		CategoryID       int
+		ControlledAmount decimal.Decimal
+	}
+	var controllable []controllableBudget
 	for _, b := range categoryBudgets {
 		if !b.ControlledAmount.IsZero() {
-			budgetMap[b.CategoryID] = b.ControlledAmount
+			controllable = append(controllable, controllableBudget{
+				CategoryID:       b.CategoryID,
+				ControlledAmount: b.ControlledAmount,
+			})
 		}
 	}
 
-	// Build controllable categories from those with non-zero controlled amounts
-	categoryMap := make(map[int]CategoryModel)
-	for _, cat := range categories {
-		categoryMap[cat.CategoryID] = cat
-	}
-
-	controllableCategories := []CategoryModel{}
-	for catID := range budgetMap {
-		if cat, ok := categoryMap[catID]; ok {
-			controllableCategories = append(controllableCategories, cat)
-		}
-	}
-
-	if len(controllableCategories) == 0 {
+	if len(controllable) == 0 {
 		return &ControllableCategoryPacing{
 			Month:              input.Month,
 			Year:               input.Year,
@@ -433,6 +418,19 @@ func (s *service) GetControllableCategoryPacing(ctx context.Context, input GetCo
 			ProgressPercentage: progressPercentage,
 			Categories:         []CategoryPacing{},
 		}, nil
+	}
+
+	// Fetch category details for each controllable budget
+	categoryMap := make(map[int]CategoryModel)
+	for _, cb := range controllable {
+		cat, err := s.Repository.FetchCategoryByID(ctx, fetchCategoryByIDParams{
+			CategoryID:     cb.CategoryID,
+			OrganizationID: input.OrganizationID,
+		})
+		if err != nil {
+			return nil, err
+		}
+		categoryMap[cb.CategoryID] = cat
 	}
 
 	// Fetch transactions for the month to calculate spending
@@ -456,40 +454,32 @@ func (s *service) GetControllableCategoryPacing(ctx context.Context, input GetCo
 	}
 
 	// Build pacing data for each controllable category
-	categoryPacingList := make([]CategoryPacing, 0, len(controllableCategories))
-	for _, cat := range controllableCategories {
-		budget := budgetMap[cat.CategoryID]
-		spent := spendingByCategory[cat.CategoryID]
+	categoryPacingList := make([]CategoryPacing, 0, len(controllable))
+	for _, cb := range controllable {
+		cat := categoryMap[cb.CategoryID]
+		budget := cb.ControlledAmount
+		spent := spendingByCategory[cb.CategoryID]
 		if spent.IsZero() {
 			spent = decimal.Zero
 		}
 
 		// Calculate expected spend: budget * (current_day / days_in_month)
-		var expected decimal.Decimal
-		var variance decimal.Decimal
+		expected := budget.Mul(decimal.NewFromInt(int64(currentDay))).Div(decimal.NewFromInt(int64(daysInMonth)))
+		variance := spent.Sub(expected)
+
+		// Determine status
+		// Within 5% of expected = on pace
+		// Below expected - 5% = under pace
+		// Above expected + 5% = over pace
+		threshold := expected.Mul(decimal.NewFromFloat(0.05))
+
 		var status CategoryPacingStatus
-
-		if budget.IsZero() {
-			expected = decimal.Zero
-			variance = decimal.Zero
-			status = PaceStatusNoBudget
+		if variance.LessThan(threshold.Neg()) {
+			status = PaceStatusUnderPace
+		} else if variance.GreaterThan(threshold) {
+			status = PaceStatusOverPace
 		} else {
-			expected = budget.Mul(decimal.NewFromInt(int64(currentDay))).Div(decimal.NewFromInt(int64(daysInMonth)))
-			variance = spent.Sub(expected)
-
-			// Determine status
-			// Within 5% of expected = on pace
-			// Below expected - 5% = under pace
-			// Above expected + 5% = over pace
-			threshold := expected.Mul(decimal.NewFromFloat(0.05))
-
-			if variance.LessThan(threshold.Neg()) {
-				status = PaceStatusUnderPace
-			} else if variance.GreaterThan(threshold) {
-				status = PaceStatusOverPace
-			} else {
-				status = PaceStatusOnPace
-			}
+			status = PaceStatusOnPace
 		}
 
 		categoryPacingList = append(categoryPacingList, CategoryPacing{

--- a/backend/internal/application/financial/budget_progress_test.go
+++ b/backend/internal/application/financial/budget_progress_test.go
@@ -406,9 +406,8 @@ func TestCalculateBudgetProgress_EdgeCase_FirstDayOfMonth(t *testing.T) {
 	mockRepo.AssertExpectations(t)
 }
 
-func TestGetControllableCategoryPacing_IncludesAllBudgetsWithControlledAmount(t *testing.T) {
+func TestGetControllableCategoryPacing_UsesNonZeroControlledAmount(t *testing.T) {
 	stubSystem := system.NewStubSystem()
-	// Fix time to March 15, 2026 for deterministic results
 	stubSystem.Time.SetTimes(time.Date(2026, 3, 15, 12, 0, 0, 0, time.UTC))
 
 	mockRepo := new(MockRepository)
@@ -419,59 +418,53 @@ func TestGetControllableCategoryPacing_IncludesAllBudgetsWithControlledAmount(t 
 
 	ctx := context.Background()
 
-	// Setup: 3 categories, only one marked as is_controllable
-	// But two have budgets with non-zero controlled_amount
-	categories := []CategoryModel{
-		{CategoryID: 1, Name: "Groceries", Icon: "🛒", IsControllable: true, CategoryType: "expense"},
-		{CategoryID: 2, Name: "Transport", Icon: "🚗", IsControllable: false, CategoryType: "expense"},
-		{CategoryID: 3, Name: "Entertainment", Icon: "🎮", IsControllable: false, CategoryType: "expense"},
-	}
-
-	// Both Groceries and Transport have non-zero controlled amounts
 	categoryBudgets := []CategoryBudgetModel{
-		{CategoryBudgetID: 1, CategoryID: 1, Month: 3, Year: 2026, ControlledAmount: decimal.NewFromFloat(500)},
-		{CategoryBudgetID: 2, CategoryID: 2, Month: 3, Year: 2026, ControlledAmount: decimal.NewFromFloat(300)},
-		// Entertainment has zero controlled amount - should NOT appear
-		{CategoryBudgetID: 3, CategoryID: 3, Month: 3, Year: 2026, ControlledAmount: decimal.Zero},
+		{CategoryBudgetID: 1, CategoryID: 10, ControlledAmount: decimal.NewFromFloat(500), Month: 3, Year: 2026, UserID: 1, OrganizationID: 1},
+		{CategoryBudgetID: 2, CategoryID: 20, ControlledAmount: decimal.NewFromFloat(300), Month: 3, Year: 2026, UserID: 1, OrganizationID: 1},
+		{CategoryBudgetID: 3, CategoryID: 30, ControlledAmount: decimal.Zero, Month: 3, Year: 2026, UserID: 1, OrganizationID: 1},
 	}
 
-	catID1 := 1
-	catID2 := 2
+	mockRepo.On("FetchCategoryBudgets", ctx, mock.MatchedBy(func(params fetchCategoryBudgetsParams) bool {
+		return params.UserID == 1 && params.OrganizationID == 1 && *params.Month == 3 && *params.Year == 2026
+	})).Return(categoryBudgets, nil)
+
+	mockRepo.On("FetchCategoryByID", ctx, mock.MatchedBy(func(params fetchCategoryByIDParams) bool {
+		return params.CategoryID == 10
+	})).Return(CategoryModel{CategoryID: 10, Name: "Food", Icon: "utensils"}, nil)
+
+	mockRepo.On("FetchCategoryByID", ctx, mock.MatchedBy(func(params fetchCategoryByIDParams) bool {
+		return params.CategoryID == 20
+	})).Return(CategoryModel{CategoryID: 20, Name: "Transport", Icon: "car"}, nil)
+
+	catID10 := 10
 	transactions := []TransactionModel{
-		{TransactionID: 1, Amount: decimal.NewFromFloat(200), TransactionType: TransactionTypeDebit, CategoryID: &catID1},
-		{TransactionID: 2, Amount: decimal.NewFromFloat(100), TransactionType: TransactionTypeDebit, CategoryID: &catID2},
+		{TransactionID: 1, Amount: decimal.NewFromFloat(200), TransactionType: TransactionTypeDebit, CategoryID: &catID10},
 	}
 
-	mockRepo.On("FetchCategories", ctx, mock.Anything).Return(categories, nil)
-	mockRepo.On("FetchCategoryBudgets", ctx, mock.Anything).Return(categoryBudgets, nil)
-	mockRepo.On("FetchTransactionsByMonth", ctx, mock.Anything).Return(transactions, nil)
+	mockRepo.On("FetchTransactionsByMonth", ctx, mock.MatchedBy(func(params fetchTransactionsByMonthParams) bool {
+		return params.OrganizationID == 1 && params.Month == 3 && params.Year == 2026
+	})).Return(transactions, nil)
 
 	result, err := svc.GetControllableCategoryPacing(ctx, GetControllableCategoryPacingInput{
-		UserID:         1,
-		OrganizationID: 1,
-		Month:          3,
-		Year:           2026,
+		UserID: 1, OrganizationID: 1, Month: 3, Year: 2026,
 	})
 
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
-	// Should include both Groceries (is_controllable) AND Transport (has controlled_amount)
-	// but NOT Entertainment (zero controlled_amount)
 	assert.Len(t, result.Categories, 2)
 
-	// Verify both categories are present
-	categoryIDs := map[int]bool{}
-	for _, cat := range result.Categories {
-		categoryIDs[cat.CategoryID] = true
+	names := map[string]bool{}
+	for _, c := range result.Categories {
+		names[c.CategoryName] = true
 	}
-	assert.True(t, categoryIDs[1], "Groceries should be included (has controlled amount)")
-	assert.True(t, categoryIDs[2], "Transport should be included (has controlled amount)")
-	assert.False(t, categoryIDs[3], "Entertainment should NOT be included (zero controlled amount)")
+	assert.True(t, names["Food"])
+	assert.True(t, names["Transport"])
 
+	mockRepo.AssertNotCalled(t, "FetchCategories", mock.Anything, mock.Anything)
 	mockRepo.AssertExpectations(t)
 }
 
-func TestGetControllableCategoryPacing_EmptyWhenNoBudgetsWithControlledAmount(t *testing.T) {
+func TestGetControllableCategoryPacing_EmptyWhenAllZeroControlledAmount(t *testing.T) {
 	stubSystem := system.NewStubSystem()
 	stubSystem.Time.SetTimes(time.Date(2026, 3, 15, 12, 0, 0, 0, time.UTC))
 
@@ -483,29 +476,26 @@ func TestGetControllableCategoryPacing_EmptyWhenNoBudgetsWithControlledAmount(t 
 
 	ctx := context.Background()
 
-	categories := []CategoryModel{
-		{CategoryID: 1, Name: "Groceries", Icon: "🛒", IsControllable: false, CategoryType: "expense"},
-	}
-
-	// Budget exists but with zero controlled amount
 	categoryBudgets := []CategoryBudgetModel{
-		{CategoryBudgetID: 1, CategoryID: 1, Month: 3, Year: 2026, ControlledAmount: decimal.Zero},
+		{CategoryBudgetID: 1, CategoryID: 10, ControlledAmount: decimal.Zero, Month: 3, Year: 2026, UserID: 1, OrganizationID: 1},
 	}
 
-	mockRepo.On("FetchCategories", ctx, mock.Anything).Return(categories, nil)
-	mockRepo.On("FetchCategoryBudgets", ctx, mock.Anything).Return(categoryBudgets, nil)
+	mockRepo.On("FetchCategoryBudgets", ctx, mock.MatchedBy(func(params fetchCategoryBudgetsParams) bool {
+		return params.UserID == 1 && params.OrganizationID == 1
+	})).Return(categoryBudgets, nil)
 
 	result, err := svc.GetControllableCategoryPacing(ctx, GetControllableCategoryPacingInput{
-		UserID:         1,
-		OrganizationID: 1,
-		Month:          3,
-		Year:           2026,
+		UserID: 1, OrganizationID: 1, Month: 3, Year: 2026,
 	})
 
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
-	assert.Len(t, result.Categories, 0)
+	assert.Empty(t, result.Categories)
+	assert.Equal(t, 3, result.Month)
+	assert.Equal(t, 2026, result.Year)
 
+	mockRepo.AssertNotCalled(t, "FetchCategories", mock.Anything, mock.Anything)
+	mockRepo.AssertNotCalled(t, "FetchTransactionsByMonth", mock.Anything, mock.Anything)
 	mockRepo.AssertExpectations(t)
 }
 


### PR DESCRIPTION
## Summary
- Removed the `FetchCategories` call from `GetControllableCategoryPacing` — it was loading all categories just to cross-reference with budget data
- Now uses `FetchCategoryByID` to fetch only the categories that have a non-zero `controlled_amount` in their budget
- Updated tests to verify `FetchCategories` is never called and `FetchCategoryByID` is used instead

## Context
Follow-up to PR #23 which introduced budget-driven controllable categories. This PR optimizes the implementation by eliminating the unnecessary bulk category fetch.

## Test plan
- [x] Unit tests verify categories with non-zero controlled amount appear in pacing
- [x] Unit tests verify empty result when all controlled amounts are zero
- [x] Tests assert `FetchCategories` is NOT called (boundary enforcement)
- [ ] Run backend tests to confirm no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)